### PR TITLE
Ignore extended fields in mavlink protocol defiinition

### DIFF
--- a/mavgen/mavgen.go
+++ b/mavgen/mavgen.go
@@ -52,6 +52,10 @@ type Message struct {
 	Name        string          `xml:"name,attr"`
 	Description string          `xml:"description"`
 	Fields      []*MessageField `xml:"field"`
+
+	// this field is only used during ParseDialect phase,
+	// it contains an empty string after ParseDialect returns
+	Raw string `xml:",innerxml"`
 }
 
 type MessageField struct {
@@ -225,6 +229,34 @@ func SanitizeComments(s string) string {
 	return strings.Replace(s, "\n", "\n// ", -1)
 }
 
+// Return the number of non-extension fields, that are contained in rawmsg, where rawmsg
+// is raw XML content of "message" element.
+func numBaseFields(rawmsg string) int {
+	dec := xml.NewDecoder(strings.NewReader(rawmsg))
+
+	fields := 0
+	for {
+		t, err := dec.Token()
+		if err != nil {
+			if err != io.EOF {
+				panic(err)
+			}
+			return fields
+		}
+		if se, ok := t.(xml.StartElement); ok {
+			switch se.Name.Local {
+			case "field":
+				fields++
+			case "extensions":
+				return fields
+			}
+			if err := dec.Skip(); err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
 // read in an xml-based dialect file,
 // and populate a Dialect struct with its contents
 func ParseDialect(in io.Reader, name string) (*Dialect, error) {
@@ -248,9 +280,16 @@ func ParseDialect(in io.Reader, name string) (*Dialect, error) {
 	n := 0
 	for _, msg := range dialect.Messages {
 		if msg.ID <= 0xff {
+			// we ignore field extensions, since they are from
+			// mavlink v2
+			ind := numBaseFields(msg.Raw)
+			if ind >= 0 {
+				msg.Fields = msg.Fields[:ind]
+			}
 			filteredMessages[n] = msg
 			n += 1
 		}
+		msg.Raw = ""
 	}
 	dialect.Messages = filteredMessages[:n]
 

--- a/mavgen/mavgen.go
+++ b/mavgen/mavgen.go
@@ -17,8 +17,7 @@ import (
 )
 
 type Dialect struct {
-	Name        string
-	StringSizes map[int]bool
+	Name string
 
 	XMLName  xml.Name   `xml:"mavlink"`
 	Version  string     `xml:"version"`

--- a/mavgen/mavgen_test.go
+++ b/mavgen/mavgen_test.go
@@ -105,10 +105,10 @@ func TestParseDialect(t *testing.T) {
 		&Message{1, "MSG1", "descr1", []*MessageField{
 			&MessageField{"uint32_t", "f1", "", "descr1", "", 0, 0, 0},
 			&MessageField{"uint8_t", "f2", "", "descr2", "", 0, 0, 0},
-		}},
+		}, ""},
 		&Message{2, "MSG2", "descr2", []*MessageField{
 			&MessageField{"uint8_t[10]", "f1", "", "descr1", "", 0, 0, 0},
-		}},
+		}, ""},
 	}
 
 	cases := []struct {
@@ -189,6 +189,76 @@ func TestParseDialect(t *testing.T) {
     </messages>
 </mavlink>`,
 			&Dialect{Version: "3", Enums: enums, Messages: messages},
+			nil,
+		},
+
+		{
+			"v2-fields",
+			`<?xml version='1.0'?>
+<mavlink>
+    <version>3</version>
+    <dialect>0</dialect>
+    <enums>
+         <enum name="MAV_AUTOPILOT">
+             <description>descr1</description>
+	     <entry value="0" name="MAV_AUTOPILOT_GENERIC"></entry>
+	     <entry value="1" name="MAV_AUTOPILOT_RESERVED"></entry>
+         </enum>
+    </enums>
+
+    <messages>
+        <message id="1" name="MSG1">
+            <description>descr1</description>
+            <field type="uint32_t" name="f1">descr1</field>
+            <field type="uint8_t" name="f2">descr2</field>
+            <extensions/>
+            <field type="uint8_t" name="f3">descr3</field>
+        </message>
+        <message id="2" name="MSG2">
+            <description>descr2</description>
+            <field type="uint8_t[10]" name="f1">descr1</field>
+            <extensions/>
+        </message>
+    </messages>
+</mavlink>`,
+			&Dialect{Version: "3", Enums: enums, Messages: messages},
+			nil,
+		},
+
+		{
+			"v2-fields-only",
+			`<?xml version='1.0'?>
+<mavlink>
+    <version>3</version>
+    <dialect>0</dialect>
+    <enums>
+         <enum name="MAV_AUTOPILOT">
+             <description>descr1</description>
+	     <entry value="0" name="MAV_AUTOPILOT_GENERIC"></entry>
+	     <entry value="1" name="MAV_AUTOPILOT_RESERVED"></entry>
+         </enum>
+    </enums>
+
+    <messages>
+        <message id="1" name="MSG1">
+            <extensions/>
+            <description>descr1</description>
+            <field type="uint32_t" name="f1">descr1</field>
+            <field type="uint8_t" name="f2">descr2</field>
+        </message>
+        <message id="2" name="MSG2">
+            <description>descr2</description>
+            <extensions/>
+        </message>
+    </messages>
+</mavlink>`,
+			&Dialect{
+				Version: "3", Enums: enums,
+				Messages: []*Message{
+					&Message{1, "MSG1", "descr1", []*MessageField{}, ""},
+					&Message{2, "MSG2", "descr2", []*MessageField(nil), ""},
+				},
+			},
 			nil,
 		},
 	}

--- a/mavlink/ardupilotmega.go
+++ b/mavlink/ardupilotmega.go
@@ -13,16 +13,6 @@ import (
 //
 //////////////////////////////////////////////////
 
-// AccelcalVehiclePos:
-const (
-	ACCELCAL_VEHICLE_POS_LEVEL    = 1 //
-	ACCELCAL_VEHICLE_POS_LEFT     = 2 //
-	ACCELCAL_VEHICLE_POS_RIGHT    = 3 //
-	ACCELCAL_VEHICLE_POS_NOSEDOWN = 4 //
-	ACCELCAL_VEHICLE_POS_NOSEUP   = 5 //
-	ACCELCAL_VEHICLE_POS_BACK     = 6 //
-)
-
 // MavCmd:
 const (
 	MAV_CMD_DO_GRIPPER                      = 211   // Mission command to operate EPM gripper
@@ -35,7 +25,6 @@ const (
 	MAV_CMD_DO_START_MAG_CAL                = 42424 // Initiate a magnetometer calibration
 	MAV_CMD_DO_ACCEPT_MAG_CAL               = 42425 // Initiate a magnetometer calibration
 	MAV_CMD_DO_CANCEL_MAG_CAL               = 42426 // Cancel a running magnetometer calibration
-	MAV_CMD_ACCELCAL_VEHICLE_POS            = 42429 // Used when doing accelerometer calibration. When sent to the GCS tells it what position to put the vehicle in. When sent to the vehicle says what position the vehicle is in.
 	MAV_CMD_DO_SEND_BANNER                  = 42428 // Reply with the version banner
 	MAV_CMD_GIMBAL_RESET                    = 42501 // Causes the gimbal to reset and boot as if it was just powered on
 	MAV_CMD_SET_FACTORY_TEST_MODE           = 42427 // Command autopilot to get into factory test/diagnostic mode
@@ -348,12 +337,11 @@ const (
 
 // PidTuningAxis:
 const (
-	PID_TUNING_ROLL    = 1 //
-	PID_TUNING_PITCH   = 2 //
-	PID_TUNING_YAW     = 3 //
-	PID_TUNING_ACCZ    = 4 //
-	PID_TUNING_STEER   = 5 //
-	PID_TUNING_LANDING = 6 //
+	PID_TUNING_ROLL  = 1 //
+	PID_TUNING_PITCH = 2 //
+	PID_TUNING_YAW   = 3 //
+	PID_TUNING_ACCZ  = 4 //
+	PID_TUNING_STEER = 5 //
 )
 
 // MagCalStatus:
@@ -376,12 +364,6 @@ const (
 const (
 	MAV_REMOTE_LOG_DATA_BLOCK_NACK = 0 // This block has NOT been received
 	MAV_REMOTE_LOG_DATA_BLOCK_ACK  = 1 // This block has been received
-)
-
-// DeviceOpBustype: Bus types for device operations
-const (
-	DEVICE_OP_BUSTYPE_I2C = 0 // I2C Device operation
-	DEVICE_OP_BUSTYPE_SPI = 1 // SPI Device operation
 )
 
 // Offsets and calibrations values for hardware sensors. This makes it easier to debug the calibration process.
@@ -739,7 +721,7 @@ type MountControl struct {
 	InputC          int32 // yaw(deg*100) or alt (in cm) depending on mount mode
 	TargetSystem    uint8 // System ID
 	TargetComponent uint8 // Component ID
-	SavePosition    uint8 // if "1" it will save current trimmed position on EEPROM (just valid for NEUTRAL and LANDING)
+	SavePosition    uint8 // if &quot;1&quot; it will save current trimmed position on EEPROM (just valid for NEUTRAL and LANDING)
 }
 
 func (self *MountControl) MsgID() MessageID {
@@ -1553,7 +1535,7 @@ func (self *RallyFetchPoint) Unpack(p *Packet) error {
 
 // Status of compassmot calibration
 type CompassmotStatus struct {
-	Current       float32 // current (Ampere)
+	Current       float32 // current (amps)
 	Compensationx float32 // Motor Compensation X
 	Compensationy float32 // Motor Compensation Y
 	Compensationz float32 // Motor Compensation Z

--- a/mavlink/common.go
+++ b/mavlink/common.go
@@ -33,6 +33,7 @@ const (
 	MAV_AUTOPILOT_ARMAZILA                                     = 15 // Armazila -- http://armazila.com
 	MAV_AUTOPILOT_AEROB                                        = 16 // Aerob -- http://aerob.ru
 	MAV_AUTOPILOT_ASLUAV                                       = 17 // ASLUAV autopilot -- http://www.asl.ethz.ch
+	MAV_AUTOPILOT_SMARTAP                                      = 18 // SmartAP Autopilot - http://sky-drones.com
 )
 
 // MavType:
@@ -138,17 +139,8 @@ const (
 // MavComponent:
 const (
 	MAV_COMP_ID_ALL            = 0   //
-	MAV_COMP_ID_GPS            = 220 //
-	MAV_COMP_ID_MISSIONPLANNER = 190 //
-	MAV_COMP_ID_PATHPLANNER    = 195 //
-	MAV_COMP_ID_MAPPER         = 180 //
+	MAV_COMP_ID_AUTOPILOT1     = 1   //
 	MAV_COMP_ID_CAMERA         = 100 //
-	MAV_COMP_ID_IMU            = 200 //
-	MAV_COMP_ID_IMU_2          = 201 //
-	MAV_COMP_ID_IMU_3          = 202 //
-	MAV_COMP_ID_UDP_BRIDGE     = 240 //
-	MAV_COMP_ID_UART_BRIDGE    = 241 //
-	MAV_COMP_ID_SYSTEM_CONTROL = 250 //
 	MAV_COMP_ID_SERVO1         = 140 //
 	MAV_COMP_ID_SERVO2         = 141 //
 	MAV_COMP_ID_SERVO3         = 142 //
@@ -169,6 +161,17 @@ const (
 	MAV_COMP_ID_OSD            = 157 // On Screen Display (OSD) devices for video links
 	MAV_COMP_ID_PERIPHERAL     = 158 // Generic autopilot peripheral component ID. Meant for devices that do not implement the parameter sub-protocol
 	MAV_COMP_ID_QX1_GIMBAL     = 159 //
+	MAV_COMP_ID_MAPPER         = 180 //
+	MAV_COMP_ID_MISSIONPLANNER = 190 //
+	MAV_COMP_ID_PATHPLANNER    = 195 //
+	MAV_COMP_ID_IMU            = 200 //
+	MAV_COMP_ID_IMU_2          = 201 //
+	MAV_COMP_ID_IMU_3          = 202 //
+	MAV_COMP_ID_GPS            = 220 //
+	MAV_COMP_ID_GPS2           = 221 //
+	MAV_COMP_ID_UDP_BRIDGE     = 240 //
+	MAV_COMP_ID_UART_BRIDGE    = 241 //
+	MAV_COMP_ID_SYSTEM_CONTROL = 250 //
 )
 
 // MavSysStatusSensor: These encode the sensors whose status is sent as part of the SYS_STATUS message.
@@ -198,6 +201,7 @@ const (
 	MAV_SYS_STATUS_TERRAIN                       = 4194304  // 0x400000 Terrain subsystem health
 	MAV_SYS_STATUS_REVERSE_MOTOR                 = 8388608  // 0x800000 Motors are reversed
 	MAV_SYS_STATUS_LOGGING                       = 16777216 // 0x1000000 Logging
+	MAV_SYS_STATUS_SENSOR_BATTERY                = 33554432 // 0x2000000 Battery
 )
 
 // MavFrame:
@@ -254,109 +258,129 @@ const (
 
 // MavCmd: Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data.
 const (
-	MAV_CMD_NAV_WAYPOINT                   = 16    // Navigate to MISSION.
-	MAV_CMD_NAV_LOITER_UNLIM               = 17    // Loiter around this MISSION an unlimited amount of time
-	MAV_CMD_NAV_LOITER_TURNS               = 18    // Loiter around this MISSION for X turns
-	MAV_CMD_NAV_LOITER_TIME                = 19    // Loiter around this MISSION for X seconds
-	MAV_CMD_NAV_RETURN_TO_LAUNCH           = 20    // Return to launch location
-	MAV_CMD_NAV_LAND                       = 21    // Land at location
-	MAV_CMD_NAV_TAKEOFF                    = 22    // Takeoff from ground / hand
-	MAV_CMD_NAV_LAND_LOCAL                 = 23    // Land at local position (local frame only)
-	MAV_CMD_NAV_TAKEOFF_LOCAL              = 24    // Takeoff from local position (local frame only)
-	MAV_CMD_NAV_FOLLOW                     = 25    // Vehicle following, i.e. this waypoint represents the position of a moving vehicle
-	MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT    = 30    // Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.
-	MAV_CMD_NAV_LOITER_TO_ALT              = 31    // Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint.
-	MAV_CMD_DO_FOLLOW                      = 32    // Being following a target
-	MAV_CMD_DO_FOLLOW_REPOSITION           = 33    // Reposition the MAV after a follow target command has been sent
-	MAV_CMD_NAV_ROI                        = 80    // Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.
-	MAV_CMD_NAV_PATHPLANNING               = 81    // Control autonomous path planning on the MAV.
-	MAV_CMD_NAV_SPLINE_WAYPOINT            = 82    // Navigate to MISSION using a spline path.
-	MAV_CMD_NAV_VTOL_TAKEOFF               = 84    // Takeoff from ground using VTOL mode
-	MAV_CMD_NAV_VTOL_LAND                  = 85    // Land using VTOL mode
-	MAV_CMD_NAV_GUIDED_ENABLE              = 92    // hand control over to an external controller
-	MAV_CMD_NAV_DELAY                      = 93    // Delay the next navigation command a number of seconds or until a specified time
-	MAV_CMD_NAV_LAST                       = 95    // NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration
-	MAV_CMD_CONDITION_DELAY                = 112   // Delay mission state machine.
-	MAV_CMD_CONDITION_CHANGE_ALT           = 113   // Ascend/descend at rate.  Delay mission state machine until desired altitude reached.
-	MAV_CMD_CONDITION_DISTANCE             = 114   // Delay mission state machine until within desired distance of next NAV point.
-	MAV_CMD_CONDITION_YAW                  = 115   // Reach a certain target angle.
-	MAV_CMD_CONDITION_LAST                 = 159   // NOP - This command is only used to mark the upper limit of the CONDITION commands in the enumeration
-	MAV_CMD_DO_SET_MODE                    = 176   // Set system mode.
-	MAV_CMD_DO_JUMP                        = 177   // Jump to the desired command in the mission list.  Repeat this action only the specified number of times
-	MAV_CMD_DO_CHANGE_SPEED                = 178   // Change speed and/or throttle set points.
-	MAV_CMD_DO_SET_HOME                    = 179   // Changes the home location either to the current location or a specified location.
-	MAV_CMD_DO_SET_PARAMETER               = 180   // Set a system parameter.  Caution!  Use of this command requires knowledge of the numeric enumeration value of the parameter.
-	MAV_CMD_DO_SET_RELAY                   = 181   // Set a relay to a condition.
-	MAV_CMD_DO_REPEAT_RELAY                = 182   // Cycle a relay on and off for a desired number of cyles with a desired period.
-	MAV_CMD_DO_SET_SERVO                   = 183   // Set a servo to a desired PWM value.
-	MAV_CMD_DO_REPEAT_SERVO                = 184   // Cycle a between its nominal setting and a desired PWM for a desired number of cycles with a desired period.
-	MAV_CMD_DO_FLIGHTTERMINATION           = 185   // Terminate flight immediately
-	MAV_CMD_DO_CHANGE_ALTITUDE             = 186   // Change altitude set point.
-	MAV_CMD_DO_LAND_START                  = 189   // Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0/0 if not needed. If specified then it will be used to help find the closest landing sequence.
-	MAV_CMD_DO_RALLY_LAND                  = 190   // Mission command to perform a landing from a rally point.
-	MAV_CMD_DO_GO_AROUND                   = 191   // Mission command to safely abort an autonmous landing.
-	MAV_CMD_DO_REPOSITION                  = 192   // Reposition the vehicle to a specific WGS84 global position.
-	MAV_CMD_DO_PAUSE_CONTINUE              = 193   // If in a GPS controlled position mode, hold the current position or continue.
-	MAV_CMD_DO_SET_REVERSE                 = 194   // Set moving direction to forward or reverse.
-	MAV_CMD_DO_CONTROL_VIDEO               = 200   // Control onboard camera system.
-	MAV_CMD_DO_SET_ROI                     = 201   // Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.
-	MAV_CMD_DO_DIGICAM_CONFIGURE           = 202   // Mission command to configure an on-board camera controller system.
-	MAV_CMD_DO_DIGICAM_CONTROL             = 203   // Mission command to control an on-board camera controller system.
-	MAV_CMD_DO_MOUNT_CONFIGURE             = 204   // Mission command to configure a camera or antenna mount
-	MAV_CMD_DO_MOUNT_CONTROL               = 205   // Mission command to control a camera or antenna mount
-	MAV_CMD_DO_SET_CAM_TRIGG_DIST          = 206   // Mission command to set CAM_TRIGG_DIST for this flight
-	MAV_CMD_DO_FENCE_ENABLE                = 207   // Mission command to enable the geofence
-	MAV_CMD_DO_PARACHUTE                   = 208   // Mission command to trigger a parachute
-	MAV_CMD_DO_MOTOR_TEST                  = 209   // Mission command to perform motor test
-	MAV_CMD_DO_INVERTED_FLIGHT             = 210   // Change to/from inverted flight
-	MAV_CMD_DO_SET_POSITION_YAW_THRUST     = 213   // Sets a desired vehicle turn angle and thrust change
-	MAV_CMD_DO_MOUNT_CONTROL_QUAT          = 220   // Mission command to control a camera or antenna mount, using a quaternion as reference.
-	MAV_CMD_DO_GUIDED_MASTER               = 221   // set id of master controller
-	MAV_CMD_DO_GUIDED_LIMITS               = 222   // set limits for external control
-	MAV_CMD_DO_ENGINE_CONTROL              = 223   // Control vehicle engine. This is interpreted by the vehicles engine controller to change the target engine state. It is intended for vehicles with internal combustion engines
-	MAV_CMD_DO_LAST                        = 240   // NOP - This command is only used to mark the upper limit of the DO commands in the enumeration
-	MAV_CMD_PREFLIGHT_CALIBRATION          = 241   // Trigger calibration. This command will be only accepted if in pre-flight mode.
-	MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS   = 242   // Set sensor offsets. This command will be only accepted if in pre-flight mode.
-	MAV_CMD_PREFLIGHT_UAVCAN               = 243   // Trigger UAVCAN config. This command will be only accepted if in pre-flight mode.
-	MAV_CMD_PREFLIGHT_STORAGE              = 245   // Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.
-	MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN      = 246   // Request the reboot or shutdown of system components.
-	MAV_CMD_OVERRIDE_GOTO                  = 252   // Hold / continue the current action
-	MAV_CMD_MISSION_START                  = 300   // start running a mission
-	MAV_CMD_COMPONENT_ARM_DISARM           = 400   // Arms / Disarms a component
-	MAV_CMD_GET_HOME_POSITION              = 410   // Request the home position from the vehicle.
-	MAV_CMD_START_RX_PAIR                  = 500   // Starts receiver pairing
-	MAV_CMD_GET_MESSAGE_INTERVAL           = 510   // Request the interval between messages for a particular MAVLink message ID
-	MAV_CMD_SET_MESSAGE_INTERVAL           = 511   // Request the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM
-	MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES = 520   // Request autopilot capabilities
-	MAV_CMD_IMAGE_START_CAPTURE            = 2000  // Start image capture sequence
-	MAV_CMD_IMAGE_STOP_CAPTURE             = 2001  // Stop image capture sequence
-	MAV_CMD_DO_TRIGGER_CONTROL             = 2003  // Enable or disable on-board camera triggering system.
-	MAV_CMD_VIDEO_START_CAPTURE            = 2500  // Starts video capture
-	MAV_CMD_VIDEO_STOP_CAPTURE             = 2501  // Stop the current video capture
-	MAV_CMD_LOGGING_START                  = 2510  // Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)
-	MAV_CMD_LOGGING_STOP                   = 2511  // Request to stop streaming log data over MAVLink
-	MAV_CMD_AIRFRAME_CONFIGURATION         = 2520  //
-	MAV_CMD_PANORAMA_CREATE                = 2800  // Create a panorama at the current position
-	MAV_CMD_DO_VTOL_TRANSITION             = 3000  // Request VTOL transition
-	MAV_CMD_SET_GUIDED_SUBMODE_STANDARD    = 4000  // This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.
-	MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE      = 4001  // This command sets submode circle when vehicle is in guided mode. Vehicle flies along a circle facing the center of the circle. The user can input the velocity along the circle and change the radius. If no input is given the vehicle will hold position.
-	MAV_CMD_PAYLOAD_PREPARE_DEPLOY         = 30001 // Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity.
-	MAV_CMD_PAYLOAD_CONTROL_DEPLOY         = 30002 // Control the payload deployment.
-	MAV_CMD_WAYPOINT_USER_1                = 31000 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
-	MAV_CMD_WAYPOINT_USER_2                = 31001 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
-	MAV_CMD_WAYPOINT_USER_3                = 31002 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
-	MAV_CMD_WAYPOINT_USER_4                = 31003 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
-	MAV_CMD_WAYPOINT_USER_5                = 31004 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
-	MAV_CMD_SPATIAL_USER_1                 = 31005 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
-	MAV_CMD_SPATIAL_USER_2                 = 31006 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
-	MAV_CMD_SPATIAL_USER_3                 = 31007 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
-	MAV_CMD_SPATIAL_USER_4                 = 31008 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
-	MAV_CMD_SPATIAL_USER_5                 = 31009 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
-	MAV_CMD_USER_1                         = 31010 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
-	MAV_CMD_USER_2                         = 31011 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
-	MAV_CMD_USER_3                         = 31012 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
-	MAV_CMD_USER_4                         = 31013 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
-	MAV_CMD_USER_5                         = 31014 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
+	MAV_CMD_NAV_WAYPOINT                       = 16    // Navigate to MISSION.
+	MAV_CMD_NAV_LOITER_UNLIM                   = 17    // Loiter around this MISSION an unlimited amount of time
+	MAV_CMD_NAV_LOITER_TURNS                   = 18    // Loiter around this MISSION for X turns
+	MAV_CMD_NAV_LOITER_TIME                    = 19    // Loiter around this MISSION for X seconds
+	MAV_CMD_NAV_RETURN_TO_LAUNCH               = 20    // Return to launch location
+	MAV_CMD_NAV_LAND                           = 21    // Land at location
+	MAV_CMD_NAV_TAKEOFF                        = 22    // Takeoff from ground / hand
+	MAV_CMD_NAV_LAND_LOCAL                     = 23    // Land at local position (local frame only)
+	MAV_CMD_NAV_TAKEOFF_LOCAL                  = 24    // Takeoff from local position (local frame only)
+	MAV_CMD_NAV_FOLLOW                         = 25    // Vehicle following, i.e. this waypoint represents the position of a moving vehicle
+	MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT        = 30    // Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.
+	MAV_CMD_NAV_LOITER_TO_ALT                  = 31    // Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint.
+	MAV_CMD_DO_FOLLOW                          = 32    // Being following a target
+	MAV_CMD_DO_FOLLOW_REPOSITION               = 33    // Reposition the MAV after a follow target command has been sent
+	MAV_CMD_NAV_ROI                            = 80    // Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.
+	MAV_CMD_NAV_PATHPLANNING                   = 81    // Control autonomous path planning on the MAV.
+	MAV_CMD_NAV_SPLINE_WAYPOINT                = 82    // Navigate to MISSION using a spline path.
+	MAV_CMD_NAV_VTOL_TAKEOFF                   = 84    // Takeoff from ground using VTOL mode
+	MAV_CMD_NAV_VTOL_LAND                      = 85    // Land using VTOL mode
+	MAV_CMD_NAV_GUIDED_ENABLE                  = 92    // hand control over to an external controller
+	MAV_CMD_NAV_DELAY                          = 93    // Delay the next navigation command a number of seconds or until a specified time
+	MAV_CMD_NAV_PAYLOAD_PLACE                  = 94    // Descend and place payload.  Vehicle descends until it detects a hanging payload has reached the ground, the gripper is opened to release the payload
+	MAV_CMD_NAV_LAST                           = 95    // NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration
+	MAV_CMD_CONDITION_DELAY                    = 112   // Delay mission state machine.
+	MAV_CMD_CONDITION_CHANGE_ALT               = 113   // Ascend/descend at rate.  Delay mission state machine until desired altitude reached.
+	MAV_CMD_CONDITION_DISTANCE                 = 114   // Delay mission state machine until within desired distance of next NAV point.
+	MAV_CMD_CONDITION_YAW                      = 115   // Reach a certain target angle.
+	MAV_CMD_CONDITION_LAST                     = 159   // NOP - This command is only used to mark the upper limit of the CONDITION commands in the enumeration
+	MAV_CMD_DO_SET_MODE                        = 176   // Set system mode.
+	MAV_CMD_DO_JUMP                            = 177   // Jump to the desired command in the mission list.  Repeat this action only the specified number of times
+	MAV_CMD_DO_CHANGE_SPEED                    = 178   // Change speed and/or throttle set points.
+	MAV_CMD_DO_SET_HOME                        = 179   // Changes the home location either to the current location or a specified location.
+	MAV_CMD_DO_SET_PARAMETER                   = 180   // Set a system parameter.  Caution!  Use of this command requires knowledge of the numeric enumeration value of the parameter.
+	MAV_CMD_DO_SET_RELAY                       = 181   // Set a relay to a condition.
+	MAV_CMD_DO_REPEAT_RELAY                    = 182   // Cycle a relay on and off for a desired number of cyles with a desired period.
+	MAV_CMD_DO_SET_SERVO                       = 183   // Set a servo to a desired PWM value.
+	MAV_CMD_DO_REPEAT_SERVO                    = 184   // Cycle a between its nominal setting and a desired PWM for a desired number of cycles with a desired period.
+	MAV_CMD_DO_FLIGHTTERMINATION               = 185   // Terminate flight immediately
+	MAV_CMD_DO_CHANGE_ALTITUDE                 = 186   // Change altitude set point.
+	MAV_CMD_DO_LAND_START                      = 189   // Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0 if not needed. If specified then it will be used to help find the closest landing sequence.
+	MAV_CMD_DO_RALLY_LAND                      = 190   // Mission command to perform a landing from a rally point.
+	MAV_CMD_DO_GO_AROUND                       = 191   // Mission command to safely abort an autonmous landing.
+	MAV_CMD_DO_REPOSITION                      = 192   // Reposition the vehicle to a specific WGS84 global position.
+	MAV_CMD_DO_PAUSE_CONTINUE                  = 193   // If in a GPS controlled position mode, hold the current position or continue.
+	MAV_CMD_DO_SET_REVERSE                     = 194   // Set moving direction to forward or reverse.
+	MAV_CMD_DO_CONTROL_VIDEO                   = 200   // Control onboard camera system.
+	MAV_CMD_DO_SET_ROI                         = 201   // Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.
+	MAV_CMD_DO_DIGICAM_CONFIGURE               = 202   // Mission command to configure an on-board camera controller system.
+	MAV_CMD_DO_DIGICAM_CONTROL                 = 203   // Mission command to control an on-board camera controller system.
+	MAV_CMD_DO_MOUNT_CONFIGURE                 = 204   // Mission command to configure a camera or antenna mount
+	MAV_CMD_DO_MOUNT_CONTROL                   = 205   // Mission command to control a camera or antenna mount
+	MAV_CMD_DO_SET_CAM_TRIGG_DIST              = 206   // Mission command to set camera trigger distance for this flight. The camera is trigerred each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera.
+	MAV_CMD_DO_FENCE_ENABLE                    = 207   // Mission command to enable the geofence
+	MAV_CMD_DO_PARACHUTE                       = 208   // Mission command to trigger a parachute
+	MAV_CMD_DO_MOTOR_TEST                      = 209   // Mission command to perform motor test
+	MAV_CMD_DO_INVERTED_FLIGHT                 = 210   // Change to/from inverted flight
+	MAV_CMD_NAV_SET_YAW_SPEED                  = 213   // Sets a desired vehicle turn angle and speed change
+	MAV_CMD_DO_SET_CAM_TRIGG_INTERVAL          = 214   // Mission command to set camera trigger interval for this flight. If triggering is enabled, the camera is triggered each time this interval expires. This command can also be used to set the shutter integration time for the camera.
+	MAV_CMD_DO_MOUNT_CONTROL_QUAT              = 220   // Mission command to control a camera or antenna mount, using a quaternion as reference.
+	MAV_CMD_DO_GUIDED_MASTER                   = 221   // set id of master controller
+	MAV_CMD_DO_GUIDED_LIMITS                   = 222   // set limits for external control
+	MAV_CMD_DO_ENGINE_CONTROL                  = 223   // Control vehicle engine. This is interpreted by the vehicles engine controller to change the target engine state. It is intended for vehicles with internal combustion engines
+	MAV_CMD_DO_LAST                            = 240   // NOP - This command is only used to mark the upper limit of the DO commands in the enumeration
+	MAV_CMD_PREFLIGHT_CALIBRATION              = 241   // Trigger calibration. This command will be only accepted if in pre-flight mode. Except for Temperature Calibration, only one sensor should be set in a single message and all others should be zero.
+	MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS       = 242   // Set sensor offsets. This command will be only accepted if in pre-flight mode.
+	MAV_CMD_PREFLIGHT_UAVCAN                   = 243   // Trigger UAVCAN config. This command will be only accepted if in pre-flight mode.
+	MAV_CMD_PREFLIGHT_STORAGE                  = 245   // Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.
+	MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN          = 246   // Request the reboot or shutdown of system components.
+	MAV_CMD_OVERRIDE_GOTO                      = 252   // Hold / continue the current action
+	MAV_CMD_MISSION_START                      = 300   // start running a mission
+	MAV_CMD_COMPONENT_ARM_DISARM               = 400   // Arms / Disarms a component
+	MAV_CMD_GET_HOME_POSITION                  = 410   // Request the home position from the vehicle.
+	MAV_CMD_START_RX_PAIR                      = 500   // Starts receiver pairing
+	MAV_CMD_GET_MESSAGE_INTERVAL               = 510   // Request the interval between messages for a particular MAVLink message ID
+	MAV_CMD_SET_MESSAGE_INTERVAL               = 511   // Request the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM
+	MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES     = 520   // Request autopilot capabilities
+	MAV_CMD_REQUEST_CAMERA_INFORMATION         = 521   // WIP: Request camera information (CAMERA_INFORMATION)
+	MAV_CMD_REQUEST_CAMERA_SETTINGS            = 522   // WIP: Request camera settings (CAMERA_SETTINGS)
+	MAV_CMD_SET_CAMERA_SETTINGS_1              = 523   // WIP: Set the camera settings part 1 (CAMERA_SETTINGS). Use NAN for values you don't want to change.
+	MAV_CMD_SET_CAMERA_SETTINGS_2              = 524   // WIP: Set the camera settings part 2 (CAMERA_SETTINGS). Use NAN for values you don't want to change.
+	MAV_CMD_REQUEST_STORAGE_INFORMATION        = 525   // WIP: Request storage information (STORAGE_INFORMATION)
+	MAV_CMD_STORAGE_FORMAT                     = 526   // WIP: Format a storage medium
+	MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS      = 527   // WIP: Request camera capture status (CAMERA_CAPTURE_STATUS)
+	MAV_CMD_REQUEST_FLIGHT_INFORMATION         = 528   // WIP: Request flight information (FLIGHT_INFORMATION)
+	MAV_CMD_RESET_CAMERA_SETTINGS              = 529   // WIP: Reset all camera settings to Factory Default (CAMERA_SETTINGS)
+	MAV_CMD_SET_CAMERA_MODE                    = 530   // WIP: Set camera running mode. Use NAN for values you don't want to change.
+	MAV_CMD_IMAGE_START_CAPTURE                = 2000  // WIP: Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture.
+	MAV_CMD_IMAGE_STOP_CAPTURE                 = 2001  // WIP: Stop image capture sequence
+	MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE       = 2002  // WIP: Re-request a CAMERA_IMAGE_CAPTURE packet
+	MAV_CMD_DO_TRIGGER_CONTROL                 = 2003  // Enable or disable on-board camera triggering system.
+	MAV_CMD_VIDEO_START_CAPTURE                = 2500  // WIP: Starts video capture (recording)
+	MAV_CMD_VIDEO_STOP_CAPTURE                 = 2501  // WIP: Stop the current video capture (recording)
+	MAV_CMD_VIDEO_START_STREAMING              = 2502  // WIP: Start video streaming
+	MAV_CMD_VIDEO_STOP_STREAMING               = 2503  // WIP: Stop the current video streaming
+	MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION   = 2504  // WIP: Request video stream information (VIDEO_STREAM_INFORMATION)
+	MAV_CMD_LOGGING_START                      = 2510  // Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)
+	MAV_CMD_LOGGING_STOP                       = 2511  // Request to stop streaming log data over MAVLink
+	MAV_CMD_AIRFRAME_CONFIGURATION             = 2520  //
+	MAV_CMD_PANORAMA_CREATE                    = 2800  // Create a panorama at the current position
+	MAV_CMD_DO_VTOL_TRANSITION                 = 3000  // Request VTOL transition
+	MAV_CMD_SET_GUIDED_SUBMODE_STANDARD        = 4000  // This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.
+	MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE          = 4001  // This command sets submode circle when vehicle is in guided mode. Vehicle flies along a circle facing the center of the circle. The user can input the velocity along the circle and change the radius. If no input is given the vehicle will hold position.
+	MAV_CMD_NAV_FENCE_RETURN_POINT             = 5000  // Fence return point. There can only be one fence return point.
+	MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION = 5001  // Fence vertex for an inclusion polygon. The vehicle must stay within this area. Minimum of 3 vertices required.
+	MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION = 5002  // Fence vertex for an exclusion polygon. The vehicle must stay outside this area. Minimum of 3 vertices required.
+	MAV_CMD_NAV_RALLY_POINT                    = 5100  // Rally point. You can have multiple rally points defined.
+	MAV_CMD_PAYLOAD_PREPARE_DEPLOY             = 30001 // Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity.
+	MAV_CMD_PAYLOAD_CONTROL_DEPLOY             = 30002 // Control the payload deployment.
+	MAV_CMD_WAYPOINT_USER_1                    = 31000 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
+	MAV_CMD_WAYPOINT_USER_2                    = 31001 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
+	MAV_CMD_WAYPOINT_USER_3                    = 31002 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
+	MAV_CMD_WAYPOINT_USER_4                    = 31003 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
+	MAV_CMD_WAYPOINT_USER_5                    = 31004 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
+	MAV_CMD_SPATIAL_USER_1                     = 31005 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
+	MAV_CMD_SPATIAL_USER_2                     = 31006 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
+	MAV_CMD_SPATIAL_USER_3                     = 31007 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
+	MAV_CMD_SPATIAL_USER_4                     = 31008 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
+	MAV_CMD_SPATIAL_USER_5                     = 31009 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
+	MAV_CMD_USER_1                             = 31010 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
+	MAV_CMD_USER_2                             = 31011 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
+	MAV_CMD_USER_3                             = 31012 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
+	MAV_CMD_USER_4                             = 31013 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
+	MAV_CMD_USER_5                             = 31014 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
 )
 
 // MavDataStream: THIS INTERFACE IS DEPRECATED AS OF JULY 2015. Please use MESSAGE_INTERVAL instead. A data stream is not a fixed set of messages, but rather a      recommendation to the autopilot software. Individual autopilots may or may not obey      the recommended messages.
@@ -415,6 +439,7 @@ const (
 	MAV_RESULT_DENIED               = 2 // Command PERMANENTLY DENIED
 	MAV_RESULT_UNSUPPORTED          = 3 // Command UNKNOWN/UNSUPPORTED
 	MAV_RESULT_FAILED               = 4 // Command executed, but failed
+	MAV_RESULT_IN_PROGRESS          = 5 // WIP: Command being executed
 )
 
 // MavMissionResult: result in a mavlink mission ack
@@ -528,20 +553,31 @@ const (
 
 // MavProtocolCapability: Bitmask of (optional) autopilot capabilities (64 bit). If a bit is set, the autopilot supports this capability.
 const (
-	MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT                  = 1    // Autopilot supports MISSION float message type.
-	MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT                    = 2    // Autopilot supports the new param float message type.
-	MAV_PROTOCOL_CAPABILITY_MISSION_INT                    = 4    // Autopilot supports MISSION_INT scaled integer message type.
-	MAV_PROTOCOL_CAPABILITY_COMMAND_INT                    = 8    // Autopilot supports COMMAND_INT scaled integer message type.
-	MAV_PROTOCOL_CAPABILITY_PARAM_UNION                    = 16   // Autopilot supports the new param union message type.
-	MAV_PROTOCOL_CAPABILITY_FTP                            = 32   // Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.
-	MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET            = 64   // Autopilot supports commanding attitude offboard.
-	MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED  = 128  // Autopilot supports commanding position and velocity targets in local NED frame.
-	MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT = 256  // Autopilot supports commanding position and velocity targets in global scaled integers.
-	MAV_PROTOCOL_CAPABILITY_TERRAIN                        = 512  // Autopilot supports terrain protocol / data handling.
-	MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET            = 1024 // Autopilot supports direct actuator control.
-	MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION             = 2048 // Autopilot supports the flight termination command.
-	MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION            = 4096 // Autopilot supports onboard compass calibration.
-	MAV_PROTOCOL_CAPABILITY_MAVLINK2                       = 8192 // Autopilot supports mavlink version 2.
+	MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT                  = 1     // Autopilot supports MISSION float message type.
+	MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT                    = 2     // Autopilot supports the new param float message type.
+	MAV_PROTOCOL_CAPABILITY_MISSION_INT                    = 4     // Autopilot supports MISSION_INT scaled integer message type.
+	MAV_PROTOCOL_CAPABILITY_COMMAND_INT                    = 8     // Autopilot supports COMMAND_INT scaled integer message type.
+	MAV_PROTOCOL_CAPABILITY_PARAM_UNION                    = 16    // Autopilot supports the new param union message type.
+	MAV_PROTOCOL_CAPABILITY_FTP                            = 32    // Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.
+	MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET            = 64    // Autopilot supports commanding attitude offboard.
+	MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED  = 128   // Autopilot supports commanding position and velocity targets in local NED frame.
+	MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT = 256   // Autopilot supports commanding position and velocity targets in global scaled integers.
+	MAV_PROTOCOL_CAPABILITY_TERRAIN                        = 512   // Autopilot supports terrain protocol / data handling.
+	MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET            = 1024  // Autopilot supports direct actuator control.
+	MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION             = 2048  // Autopilot supports the flight termination command.
+	MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION            = 4096  // Autopilot supports onboard compass calibration.
+	MAV_PROTOCOL_CAPABILITY_MAVLINK2                       = 8192  // Autopilot supports mavlink version 2.
+	MAV_PROTOCOL_CAPABILITY_MISSION_FENCE                  = 16384 // Autopilot supports mission fence protocol.
+	MAV_PROTOCOL_CAPABILITY_MISSION_RALLY                  = 32768 // Autopilot supports mission rally point protocol.
+	MAV_PROTOCOL_CAPABILITY_FLIGHT_INFORMATION             = 65536 // Autopilot supports the flight information protocol.
+)
+
+// MavMissionType: Type of mission items being requested/sent in mission protocol.
+const (
+	MAV_MISSION_TYPE_MISSION = 0   // Items are mission commands for main mission.
+	MAV_MISSION_TYPE_FENCE   = 1   // Specifies GeoFence area(s). Items are MAV_CMD_FENCE_ GeoFence items.
+	MAV_MISSION_TYPE_RALLY   = 2   // Specifies the rally points for the vehicle. Rally points are alternative RTL points. Items are MAV_CMD_RALLY_POINT rally point items.
+	MAV_MISSION_TYPE_ALL     = 255 // Only used in MISSION_CLEAR_ALL to clear all mission types.
 )
 
 // MavEstimatorType: Enumeration of estimator types
@@ -585,6 +621,8 @@ const (
 	MAV_LANDED_STATE_UNDEFINED = 0 // MAV landed state is unknown
 	MAV_LANDED_STATE_ON_GROUND = 1 // MAV is landed (on ground)
 	MAV_LANDED_STATE_IN_AIR    = 2 // MAV is in air
+	MAV_LANDED_STATE_TAKEOFF   = 3 // MAV currently taking off
+	MAV_LANDED_STATE_LANDING   = 4 // MAV currently landing
 )
 
 // AdsbAltitudeType: Enumeration of the ADSB altimeter types
@@ -671,8 +709,8 @@ const (
 const (
 	MAV_COLLISION_ACTION_NONE               = 0 // Ignore any potential collisions
 	MAV_COLLISION_ACTION_REPORT             = 1 // Report potential collision
-	MAV_COLLISION_ACTION_ASCEND_OR_DESCEND  = 2 // Ascend or Descend to avoid thread
-	MAV_COLLISION_ACTION_MOVE_HORIZONTALLY  = 3 // Ascend or Descend to avoid thread
+	MAV_COLLISION_ACTION_ASCEND_OR_DESCEND  = 2 // Ascend or Descend to avoid threat
+	MAV_COLLISION_ACTION_MOVE_HORIZONTALLY  = 3 // Move horizontally to avoid threat
 	MAV_COLLISION_ACTION_MOVE_PERPENDICULAR = 4 // Aircraft to move perpendicular to the collision's velocity vector
 	MAV_COLLISION_ACTION_RTL                = 5 // Aircraft to fly directly back to its launch point
 	MAV_COLLISION_ACTION_HOVER              = 6 // Aircraft to stop in place
@@ -1805,24 +1843,16 @@ func (self *RcChannelsRaw) Unpack(p *Packet) error {
 
 // The RAW values of the servo outputs (for RC input from the remote, use the RC_CHANNELS messages). The standard PPM modulation is as follows: 1000 microseconds: 0%, 2000 microseconds: 100%.
 type ServoOutputRaw struct {
-	TimeUsec   uint32 // Timestamp (microseconds since system boot)
-	Servo1Raw  uint16 // Servo output 1 value, in microseconds
-	Servo2Raw  uint16 // Servo output 2 value, in microseconds
-	Servo3Raw  uint16 // Servo output 3 value, in microseconds
-	Servo4Raw  uint16 // Servo output 4 value, in microseconds
-	Servo5Raw  uint16 // Servo output 5 value, in microseconds
-	Servo6Raw  uint16 // Servo output 6 value, in microseconds
-	Servo7Raw  uint16 // Servo output 7 value, in microseconds
-	Servo8Raw  uint16 // Servo output 8 value, in microseconds
-	Servo9Raw  uint16 // Servo output 9 value, in microseconds
-	Servo10Raw uint16 // Servo output 10 value, in microseconds
-	Servo11Raw uint16 // Servo output 11 value, in microseconds
-	Servo12Raw uint16 // Servo output 12 value, in microseconds
-	Servo13Raw uint16 // Servo output 13 value, in microseconds
-	Servo14Raw uint16 // Servo output 14 value, in microseconds
-	Servo15Raw uint16 // Servo output 15 value, in microseconds
-	Servo16Raw uint16 // Servo output 16 value, in microseconds
-	Port       uint8  // Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.
+	TimeUsec  uint32 // Timestamp (microseconds since system boot)
+	Servo1Raw uint16 // Servo output 1 value, in microseconds
+	Servo2Raw uint16 // Servo output 2 value, in microseconds
+	Servo3Raw uint16 // Servo output 3 value, in microseconds
+	Servo4Raw uint16 // Servo output 4 value, in microseconds
+	Servo5Raw uint16 // Servo output 5 value, in microseconds
+	Servo6Raw uint16 // Servo output 6 value, in microseconds
+	Servo7Raw uint16 // Servo output 7 value, in microseconds
+	Servo8Raw uint16 // Servo output 8 value, in microseconds
+	Port      uint8  // Servo output port (set of 8 outputs = 1 port). Most MAVs will just use one, but this allows to encode more than 8 servos.
 }
 
 func (self *ServoOutputRaw) MsgID() MessageID {
@@ -1834,7 +1864,7 @@ func (self *ServoOutputRaw) MsgName() string {
 }
 
 func (self *ServoOutputRaw) Pack(p *Packet) error {
-	payload := make([]byte, 37)
+	payload := make([]byte, 21)
 	binary.LittleEndian.PutUint32(payload[0:], uint32(self.TimeUsec))
 	binary.LittleEndian.PutUint16(payload[4:], uint16(self.Servo1Raw))
 	binary.LittleEndian.PutUint16(payload[6:], uint16(self.Servo2Raw))
@@ -1844,15 +1874,7 @@ func (self *ServoOutputRaw) Pack(p *Packet) error {
 	binary.LittleEndian.PutUint16(payload[14:], uint16(self.Servo6Raw))
 	binary.LittleEndian.PutUint16(payload[16:], uint16(self.Servo7Raw))
 	binary.LittleEndian.PutUint16(payload[18:], uint16(self.Servo8Raw))
-	binary.LittleEndian.PutUint16(payload[20:], uint16(self.Servo9Raw))
-	binary.LittleEndian.PutUint16(payload[22:], uint16(self.Servo10Raw))
-	binary.LittleEndian.PutUint16(payload[24:], uint16(self.Servo11Raw))
-	binary.LittleEndian.PutUint16(payload[26:], uint16(self.Servo12Raw))
-	binary.LittleEndian.PutUint16(payload[28:], uint16(self.Servo13Raw))
-	binary.LittleEndian.PutUint16(payload[30:], uint16(self.Servo14Raw))
-	binary.LittleEndian.PutUint16(payload[32:], uint16(self.Servo15Raw))
-	binary.LittleEndian.PutUint16(payload[34:], uint16(self.Servo16Raw))
-	payload[36] = byte(self.Port)
+	payload[20] = byte(self.Port)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -1860,7 +1882,7 @@ func (self *ServoOutputRaw) Pack(p *Packet) error {
 }
 
 func (self *ServoOutputRaw) Unpack(p *Packet) error {
-	if len(p.Payload) < 37 {
+	if len(p.Payload) < 21 {
 		return fmt.Errorf("payload too small")
 	}
 	self.TimeUsec = uint32(binary.LittleEndian.Uint32(p.Payload[0:]))
@@ -1872,15 +1894,7 @@ func (self *ServoOutputRaw) Unpack(p *Packet) error {
 	self.Servo6Raw = uint16(binary.LittleEndian.Uint16(p.Payload[14:]))
 	self.Servo7Raw = uint16(binary.LittleEndian.Uint16(p.Payload[16:]))
 	self.Servo8Raw = uint16(binary.LittleEndian.Uint16(p.Payload[18:]))
-	self.Servo9Raw = uint16(binary.LittleEndian.Uint16(p.Payload[20:]))
-	self.Servo10Raw = uint16(binary.LittleEndian.Uint16(p.Payload[22:]))
-	self.Servo11Raw = uint16(binary.LittleEndian.Uint16(p.Payload[24:]))
-	self.Servo12Raw = uint16(binary.LittleEndian.Uint16(p.Payload[26:]))
-	self.Servo13Raw = uint16(binary.LittleEndian.Uint16(p.Payload[28:]))
-	self.Servo14Raw = uint16(binary.LittleEndian.Uint16(p.Payload[30:]))
-	self.Servo15Raw = uint16(binary.LittleEndian.Uint16(p.Payload[32:]))
-	self.Servo16Raw = uint16(binary.LittleEndian.Uint16(p.Payload[34:]))
-	self.Port = uint8(p.Payload[36])
+	self.Port = uint8(p.Payload[20])
 	return nil
 }
 
@@ -2571,7 +2585,7 @@ func (self *SafetyAllowedArea) Unpack(p *Packet) error {
 
 // The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).
 type AttitudeQuaternionCov struct {
-	TimeBootMs uint32     // Timestamp (milliseconds since system boot)
+	TimeUsec   uint64     // Timestamp (microseconds since system boot or since UNIX epoch)
 	Q          [4]float32 // Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)
 	Rollspeed  float32    // Roll angular speed (rad/s)
 	Pitchspeed float32    // Pitch angular speed (rad/s)
@@ -2588,16 +2602,16 @@ func (self *AttitudeQuaternionCov) MsgName() string {
 }
 
 func (self *AttitudeQuaternionCov) Pack(p *Packet) error {
-	payload := make([]byte, 68)
-	binary.LittleEndian.PutUint32(payload[0:], uint32(self.TimeBootMs))
+	payload := make([]byte, 72)
+	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUsec))
 	for i, v := range self.Q {
-		binary.LittleEndian.PutUint32(payload[4+i*4:], math.Float32bits(v))
+		binary.LittleEndian.PutUint32(payload[8+i*4:], math.Float32bits(v))
 	}
-	binary.LittleEndian.PutUint32(payload[20:], math.Float32bits(self.Rollspeed))
-	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.Pitchspeed))
-	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Yawspeed))
+	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.Rollspeed))
+	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Pitchspeed))
+	binary.LittleEndian.PutUint32(payload[32:], math.Float32bits(self.Yawspeed))
 	for i, v := range self.Covariance {
-		binary.LittleEndian.PutUint32(payload[32+i*4:], math.Float32bits(v))
+		binary.LittleEndian.PutUint32(payload[36+i*4:], math.Float32bits(v))
 	}
 
 	p.MsgID = self.MsgID()
@@ -2606,18 +2620,18 @@ func (self *AttitudeQuaternionCov) Pack(p *Packet) error {
 }
 
 func (self *AttitudeQuaternionCov) Unpack(p *Packet) error {
-	if len(p.Payload) < 68 {
+	if len(p.Payload) < 72 {
 		return fmt.Errorf("payload too small")
 	}
-	self.TimeBootMs = uint32(binary.LittleEndian.Uint32(p.Payload[0:]))
+	self.TimeUsec = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
 	for i := 0; i < len(self.Q); i++ {
-		self.Q[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[4+i*4:]))
+		self.Q[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8+i*4:]))
 	}
-	self.Rollspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[20:]))
-	self.Pitchspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
-	self.Yawspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
+	self.Rollspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
+	self.Pitchspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
+	self.Yawspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32:]))
 	for i := 0; i < len(self.Covariance); i++ {
-		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32+i*4:]))
+		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[36+i*4:]))
 	}
 	return nil
 }
@@ -2675,8 +2689,7 @@ func (self *NavControllerOutput) Unpack(p *Packet) error {
 
 // The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It  is designed as scaled integer message since the resolution of float is not sufficient. NOTE: This message is intended for onboard networks / companion computers and higher-bandwidth links and optimized for accuracy and completeness. Please use the GLOBAL_POSITION_INT message for a minimal subset.
 type GlobalPositionIntCov struct {
-	TimeUtc       uint64      // Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown. Commonly filled by the precision time source of a GPS receiver.
-	TimeBootMs    uint32      // Timestamp (milliseconds since system boot)
+	TimeUsec      uint64      // Timestamp (microseconds since system boot or since UNIX epoch)
 	Lat           int32       // Latitude, expressed as degrees * 1E7
 	Lon           int32       // Longitude, expressed as degrees * 1E7
 	Alt           int32       // Altitude in meters, expressed as * 1000 (millimeters), above MSL
@@ -2697,20 +2710,19 @@ func (self *GlobalPositionIntCov) MsgName() string {
 }
 
 func (self *GlobalPositionIntCov) Pack(p *Packet) error {
-	payload := make([]byte, 185)
-	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUtc))
-	binary.LittleEndian.PutUint32(payload[8:], uint32(self.TimeBootMs))
-	binary.LittleEndian.PutUint32(payload[12:], uint32(self.Lat))
-	binary.LittleEndian.PutUint32(payload[16:], uint32(self.Lon))
-	binary.LittleEndian.PutUint32(payload[20:], uint32(self.Alt))
-	binary.LittleEndian.PutUint32(payload[24:], uint32(self.RelativeAlt))
-	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Vx))
-	binary.LittleEndian.PutUint32(payload[32:], math.Float32bits(self.Vy))
-	binary.LittleEndian.PutUint32(payload[36:], math.Float32bits(self.Vz))
+	payload := make([]byte, 181)
+	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUsec))
+	binary.LittleEndian.PutUint32(payload[8:], uint32(self.Lat))
+	binary.LittleEndian.PutUint32(payload[12:], uint32(self.Lon))
+	binary.LittleEndian.PutUint32(payload[16:], uint32(self.Alt))
+	binary.LittleEndian.PutUint32(payload[20:], uint32(self.RelativeAlt))
+	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.Vx))
+	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Vy))
+	binary.LittleEndian.PutUint32(payload[32:], math.Float32bits(self.Vz))
 	for i, v := range self.Covariance {
-		binary.LittleEndian.PutUint32(payload[40+i*4:], math.Float32bits(v))
+		binary.LittleEndian.PutUint32(payload[36+i*4:], math.Float32bits(v))
 	}
-	payload[184] = byte(self.EstimatorType)
+	payload[180] = byte(self.EstimatorType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2718,29 +2730,27 @@ func (self *GlobalPositionIntCov) Pack(p *Packet) error {
 }
 
 func (self *GlobalPositionIntCov) Unpack(p *Packet) error {
-	if len(p.Payload) < 185 {
+	if len(p.Payload) < 181 {
 		return fmt.Errorf("payload too small")
 	}
-	self.TimeUtc = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
-	self.TimeBootMs = uint32(binary.LittleEndian.Uint32(p.Payload[8:]))
-	self.Lat = int32(binary.LittleEndian.Uint32(p.Payload[12:]))
-	self.Lon = int32(binary.LittleEndian.Uint32(p.Payload[16:]))
-	self.Alt = int32(binary.LittleEndian.Uint32(p.Payload[20:]))
-	self.RelativeAlt = int32(binary.LittleEndian.Uint32(p.Payload[24:]))
-	self.Vx = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
-	self.Vy = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32:]))
-	self.Vz = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[36:]))
+	self.TimeUsec = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
+	self.Lat = int32(binary.LittleEndian.Uint32(p.Payload[8:]))
+	self.Lon = int32(binary.LittleEndian.Uint32(p.Payload[12:]))
+	self.Alt = int32(binary.LittleEndian.Uint32(p.Payload[16:]))
+	self.RelativeAlt = int32(binary.LittleEndian.Uint32(p.Payload[20:]))
+	self.Vx = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
+	self.Vy = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
+	self.Vz = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32:]))
 	for i := 0; i < len(self.Covariance); i++ {
-		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[40+i*4:]))
+		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[36+i*4:]))
 	}
-	self.EstimatorType = uint8(p.Payload[184])
+	self.EstimatorType = uint8(p.Payload[180])
 	return nil
 }
 
 // The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)
 type LocalPositionNedCov struct {
-	TimeUtc       uint64      // Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown. Commonly filled by the precision time source of a GPS receiver.
-	TimeBootMs    uint32      // Timestamp (milliseconds since system boot). 0 for system without monotonic timestamp
+	TimeUsec      uint64      // Timestamp (microseconds since system boot or since UNIX epoch)
 	X             float32     // X Position
 	Y             float32     // Y Position
 	Z             float32     // Z Position
@@ -2763,22 +2773,21 @@ func (self *LocalPositionNedCov) MsgName() string {
 }
 
 func (self *LocalPositionNedCov) Pack(p *Packet) error {
-	payload := make([]byte, 229)
-	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUtc))
-	binary.LittleEndian.PutUint32(payload[8:], uint32(self.TimeBootMs))
-	binary.LittleEndian.PutUint32(payload[12:], math.Float32bits(self.X))
-	binary.LittleEndian.PutUint32(payload[16:], math.Float32bits(self.Y))
-	binary.LittleEndian.PutUint32(payload[20:], math.Float32bits(self.Z))
-	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.Vx))
-	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Vy))
-	binary.LittleEndian.PutUint32(payload[32:], math.Float32bits(self.Vz))
-	binary.LittleEndian.PutUint32(payload[36:], math.Float32bits(self.Ax))
-	binary.LittleEndian.PutUint32(payload[40:], math.Float32bits(self.Ay))
-	binary.LittleEndian.PutUint32(payload[44:], math.Float32bits(self.Az))
+	payload := make([]byte, 225)
+	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUsec))
+	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.X))
+	binary.LittleEndian.PutUint32(payload[12:], math.Float32bits(self.Y))
+	binary.LittleEndian.PutUint32(payload[16:], math.Float32bits(self.Z))
+	binary.LittleEndian.PutUint32(payload[20:], math.Float32bits(self.Vx))
+	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.Vy))
+	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Vz))
+	binary.LittleEndian.PutUint32(payload[32:], math.Float32bits(self.Ax))
+	binary.LittleEndian.PutUint32(payload[36:], math.Float32bits(self.Ay))
+	binary.LittleEndian.PutUint32(payload[40:], math.Float32bits(self.Az))
 	for i, v := range self.Covariance {
-		binary.LittleEndian.PutUint32(payload[48+i*4:], math.Float32bits(v))
+		binary.LittleEndian.PutUint32(payload[44+i*4:], math.Float32bits(v))
 	}
-	payload[228] = byte(self.EstimatorType)
+	payload[224] = byte(self.EstimatorType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2786,24 +2795,23 @@ func (self *LocalPositionNedCov) Pack(p *Packet) error {
 }
 
 func (self *LocalPositionNedCov) Unpack(p *Packet) error {
-	if len(p.Payload) < 229 {
+	if len(p.Payload) < 225 {
 		return fmt.Errorf("payload too small")
 	}
-	self.TimeUtc = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
-	self.TimeBootMs = uint32(binary.LittleEndian.Uint32(p.Payload[8:]))
-	self.X = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[12:]))
-	self.Y = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[16:]))
-	self.Z = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[20:]))
-	self.Vx = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
-	self.Vy = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
-	self.Vz = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32:]))
-	self.Ax = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[36:]))
-	self.Ay = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[40:]))
-	self.Az = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[44:]))
+	self.TimeUsec = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
+	self.X = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8:]))
+	self.Y = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[12:]))
+	self.Z = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[16:]))
+	self.Vx = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[20:]))
+	self.Vy = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
+	self.Vz = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
+	self.Ax = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32:]))
+	self.Ay = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[36:]))
+	self.Az = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[40:]))
 	for i := 0; i < len(self.Covariance); i++ {
-		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[48+i*4:]))
+		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[44+i*4:]))
 	}
-	self.EstimatorType = uint8(p.Payload[228])
+	self.EstimatorType = uint8(p.Payload[224])
 	return nil
 }
 
@@ -3462,8 +3470,8 @@ type AttitudeTarget struct {
 	TimeBootMs    uint32     // Timestamp in milliseconds since system boot
 	Q             [4]float32 // Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
 	BodyRollRate  float32    // Body roll rate in radians per second
-	BodyPitchRate float32    // Body roll rate in radians per second
-	BodyYawRate   float32    // Body roll rate in radians per second
+	BodyPitchRate float32    // Body pitch rate in radians per second
+	BodyYawRate   float32    // Body yaw rate in radians per second
 	Thrust        float32    // Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)
 	TypeMask      uint8      // Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 7: reserved, bit 8: attitude
 }
@@ -4785,7 +4793,7 @@ type HilGps struct {
 	Alt               int32  // Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)
 	Eph               uint16 // GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: 65535
 	Epv               uint16 // GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: 65535
-	Vel               uint16 // GPS ground speed (m/s * 100). If unknown, set to: 65535
+	Vel               uint16 // GPS ground speed in cm/s. If unknown, set to: 65535
 	Vn                int16  // GPS velocity in cm/s in NORTH direction in earth-fixed NED frame
 	Ve                int16  // GPS velocity in cm/s in EAST direction in earth-fixed NED frame
 	Vd                int16  // GPS velocity in cm/s in DOWN direction in earth-fixed NED frame
@@ -4916,11 +4924,11 @@ type HilStateQuaternion struct {
 	Lat                int32      // Latitude, expressed as * 1E7
 	Lon                int32      // Longitude, expressed as * 1E7
 	Alt                int32      // Altitude in meters, expressed as * 1000 (millimeters)
-	Vx                 int16      // Ground X Speed (Latitude), expressed as m/s * 100
-	Vy                 int16      // Ground Y Speed (Longitude), expressed as m/s * 100
-	Vz                 int16      // Ground Z Speed (Altitude), expressed as m/s * 100
-	IndAirspeed        uint16     // Indicated airspeed, expressed as m/s * 100
-	TrueAirspeed       uint16     // True airspeed, expressed as m/s * 100
+	Vx                 int16      // Ground X Speed (Latitude), expressed as cm/s
+	Vy                 int16      // Ground Y Speed (Longitude), expressed as cm/s
+	Vz                 int16      // Ground Z Speed (Altitude), expressed as cm/s
+	IndAirspeed        uint16     // Indicated airspeed, expressed as cm/s
+	TrueAirspeed       uint16     // True airspeed, expressed as cm/s
 	Xacc               int16      // X acceleration (mg)
 	Yacc               int16      // Y acceleration (mg)
 	Zacc               int16      // Z acceleration (mg)
@@ -6413,7 +6421,7 @@ func (self *ControlSystemState) Unpack(p *Packet) error {
 // Battery information
 type BatteryStatus struct {
 	CurrentConsumed  int32      // Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate
-	EnergyConsumed   int32      // Consumed energy, in 100*Joules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate
+	EnergyConsumed   int32      // Consumed energy, in HectoJoules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate
 	Temperature      int16      // Temperature of the battery in centi-degrees celsius. INT16_MAX for unknown temperature.
 	Voltages         [10]uint16 // Battery voltage of cells, in millivolts (1 = 1 millivolt). Cells above the valid cell count for this battery should have the UINT16_MAX value.
 	CurrentBattery   int16      // Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current
@@ -6771,9 +6779,9 @@ func (self *GpsInput) Unpack(p *Packet) error {
 	return nil
 }
 
-// WORK IN PROGRESS! RTCM message for injecting into the onboard GPS (used for DGPS)
+// RTCM message for injecting into the onboard GPS (used for DGPS)
 type GpsRtcmData struct {
-	Flags uint8      // LSB: 1 means message is fragmented
+	Flags uint8      // LSB: 1 means message is fragmented, next 2 bits are the fragment ID, the remaining 5 bits are used for the sequence ID. Messages are only to be flushed to the GPS when the entire message has been reconstructed on the autopilot. The fragment ID specifies which order the fragments should be assembled into a buffer, while the sequence ID is used to detect a mismatch between different buffers. The buffer is considered fully reconstructed when either all 4 fragments are present, or all the fragments before the first fragment with a non full payload is received. This management is used to ensure that normal GPS operation doesn't corrupt RTCM data, and to recover from a unreliable transport delivery order.
 	Len   uint8      // data length
 	Data  [180]uint8 // RTCM message (may be fragmented)
 }
@@ -6809,17 +6817,13 @@ func (self *GpsRtcmData) Unpack(p *Packet) error {
 
 // Message appropriate for high latency connections like Iridium
 type HighLatency struct {
-	TimeUsec         uint64 // Timestamp (microseconds since UNIX epoch)
 	CustomMode       uint32 // A bitfield for use for autopilot-specific flags.
 	Latitude         int32  // Latitude, expressed as degrees * 1E7
 	Longitude        int32  // Longitude, expressed as degrees * 1E7
 	Roll             int16  // roll (centidegrees)
 	Pitch            int16  // pitch (centidegrees)
 	Heading          uint16 // heading (centidegrees)
-	RollSp           int16  // roll setpoint (centidegrees)
-	PitchSp          int16  // pitch setpoint (centidegrees)
 	HeadingSp        int16  // heading setpoint (centidegrees)
-	AltitudeHome     int16  // Altitude above the home position (meters)
 	AltitudeAmsl     int16  // Altitude above mean sea level (meters)
 	AltitudeSp       int16  // Altitude setpoint relative to the home position (meters)
 	WpDistance       uint16 // distance to target (meters)
@@ -6848,35 +6852,31 @@ func (self *HighLatency) MsgName() string {
 }
 
 func (self *HighLatency) Pack(p *Packet) error {
-	payload := make([]byte, 54)
-	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUsec))
-	binary.LittleEndian.PutUint32(payload[8:], uint32(self.CustomMode))
-	binary.LittleEndian.PutUint32(payload[12:], uint32(self.Latitude))
-	binary.LittleEndian.PutUint32(payload[16:], uint32(self.Longitude))
-	binary.LittleEndian.PutUint16(payload[20:], uint16(self.Roll))
-	binary.LittleEndian.PutUint16(payload[22:], uint16(self.Pitch))
-	binary.LittleEndian.PutUint16(payload[24:], uint16(self.Heading))
-	binary.LittleEndian.PutUint16(payload[26:], uint16(self.RollSp))
-	binary.LittleEndian.PutUint16(payload[28:], uint16(self.PitchSp))
-	binary.LittleEndian.PutUint16(payload[30:], uint16(self.HeadingSp))
-	binary.LittleEndian.PutUint16(payload[32:], uint16(self.AltitudeHome))
-	binary.LittleEndian.PutUint16(payload[34:], uint16(self.AltitudeAmsl))
-	binary.LittleEndian.PutUint16(payload[36:], uint16(self.AltitudeSp))
-	binary.LittleEndian.PutUint16(payload[38:], uint16(self.WpDistance))
-	payload[40] = byte(self.BaseMode)
-	payload[41] = byte(self.LandedState)
-	payload[42] = byte(self.Throttle)
-	payload[43] = byte(self.Airspeed)
-	payload[44] = byte(self.AirspeedSp)
-	payload[45] = byte(self.Groundspeed)
-	payload[46] = byte(self.ClimbRate)
-	payload[47] = byte(self.GpsNsat)
-	payload[48] = byte(self.GpsFixType)
-	payload[49] = byte(self.BatteryRemaining)
-	payload[50] = byte(self.Temperature)
-	payload[51] = byte(self.TemperatureAir)
-	payload[52] = byte(self.Failsafe)
-	payload[53] = byte(self.WpNum)
+	payload := make([]byte, 40)
+	binary.LittleEndian.PutUint32(payload[0:], uint32(self.CustomMode))
+	binary.LittleEndian.PutUint32(payload[4:], uint32(self.Latitude))
+	binary.LittleEndian.PutUint32(payload[8:], uint32(self.Longitude))
+	binary.LittleEndian.PutUint16(payload[12:], uint16(self.Roll))
+	binary.LittleEndian.PutUint16(payload[14:], uint16(self.Pitch))
+	binary.LittleEndian.PutUint16(payload[16:], uint16(self.Heading))
+	binary.LittleEndian.PutUint16(payload[18:], uint16(self.HeadingSp))
+	binary.LittleEndian.PutUint16(payload[20:], uint16(self.AltitudeAmsl))
+	binary.LittleEndian.PutUint16(payload[22:], uint16(self.AltitudeSp))
+	binary.LittleEndian.PutUint16(payload[24:], uint16(self.WpDistance))
+	payload[26] = byte(self.BaseMode)
+	payload[27] = byte(self.LandedState)
+	payload[28] = byte(self.Throttle)
+	payload[29] = byte(self.Airspeed)
+	payload[30] = byte(self.AirspeedSp)
+	payload[31] = byte(self.Groundspeed)
+	payload[32] = byte(self.ClimbRate)
+	payload[33] = byte(self.GpsNsat)
+	payload[34] = byte(self.GpsFixType)
+	payload[35] = byte(self.BatteryRemaining)
+	payload[36] = byte(self.Temperature)
+	payload[37] = byte(self.TemperatureAir)
+	payload[38] = byte(self.Failsafe)
+	payload[39] = byte(self.WpNum)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -6884,37 +6884,33 @@ func (self *HighLatency) Pack(p *Packet) error {
 }
 
 func (self *HighLatency) Unpack(p *Packet) error {
-	if len(p.Payload) < 54 {
+	if len(p.Payload) < 40 {
 		return fmt.Errorf("payload too small")
 	}
-	self.TimeUsec = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
-	self.CustomMode = uint32(binary.LittleEndian.Uint32(p.Payload[8:]))
-	self.Latitude = int32(binary.LittleEndian.Uint32(p.Payload[12:]))
-	self.Longitude = int32(binary.LittleEndian.Uint32(p.Payload[16:]))
-	self.Roll = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
-	self.Pitch = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
-	self.Heading = uint16(binary.LittleEndian.Uint16(p.Payload[24:]))
-	self.RollSp = int16(binary.LittleEndian.Uint16(p.Payload[26:]))
-	self.PitchSp = int16(binary.LittleEndian.Uint16(p.Payload[28:]))
-	self.HeadingSp = int16(binary.LittleEndian.Uint16(p.Payload[30:]))
-	self.AltitudeHome = int16(binary.LittleEndian.Uint16(p.Payload[32:]))
-	self.AltitudeAmsl = int16(binary.LittleEndian.Uint16(p.Payload[34:]))
-	self.AltitudeSp = int16(binary.LittleEndian.Uint16(p.Payload[36:]))
-	self.WpDistance = uint16(binary.LittleEndian.Uint16(p.Payload[38:]))
-	self.BaseMode = uint8(p.Payload[40])
-	self.LandedState = uint8(p.Payload[41])
-	self.Throttle = int8(p.Payload[42])
-	self.Airspeed = uint8(p.Payload[43])
-	self.AirspeedSp = uint8(p.Payload[44])
-	self.Groundspeed = uint8(p.Payload[45])
-	self.ClimbRate = int8(p.Payload[46])
-	self.GpsNsat = uint8(p.Payload[47])
-	self.GpsFixType = uint8(p.Payload[48])
-	self.BatteryRemaining = uint8(p.Payload[49])
-	self.Temperature = int8(p.Payload[50])
-	self.TemperatureAir = int8(p.Payload[51])
-	self.Failsafe = uint8(p.Payload[52])
-	self.WpNum = uint8(p.Payload[53])
+	self.CustomMode = uint32(binary.LittleEndian.Uint32(p.Payload[0:]))
+	self.Latitude = int32(binary.LittleEndian.Uint32(p.Payload[4:]))
+	self.Longitude = int32(binary.LittleEndian.Uint32(p.Payload[8:]))
+	self.Roll = int16(binary.LittleEndian.Uint16(p.Payload[12:]))
+	self.Pitch = int16(binary.LittleEndian.Uint16(p.Payload[14:]))
+	self.Heading = uint16(binary.LittleEndian.Uint16(p.Payload[16:]))
+	self.HeadingSp = int16(binary.LittleEndian.Uint16(p.Payload[18:]))
+	self.AltitudeAmsl = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
+	self.AltitudeSp = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
+	self.WpDistance = uint16(binary.LittleEndian.Uint16(p.Payload[24:]))
+	self.BaseMode = uint8(p.Payload[26])
+	self.LandedState = uint8(p.Payload[27])
+	self.Throttle = int8(p.Payload[28])
+	self.Airspeed = uint8(p.Payload[29])
+	self.AirspeedSp = uint8(p.Payload[30])
+	self.Groundspeed = uint8(p.Payload[31])
+	self.ClimbRate = int8(p.Payload[32])
+	self.GpsNsat = uint8(p.Payload[33])
+	self.GpsFixType = uint8(p.Payload[34])
+	self.BatteryRemaining = uint8(p.Payload[35])
+	self.Temperature = int8(p.Payload[36])
+	self.TemperatureAir = int8(p.Payload[37])
+	self.Failsafe = uint8(p.Payload[38])
+	self.WpNum = uint8(p.Payload[39])
 	return nil
 }
 
@@ -7093,7 +7089,7 @@ func (self *SetHomePosition) Unpack(p *Packet) error {
 
 // This interface replaces DATA_STREAM
 type MessageInterval struct {
-	IntervalUs int32  // The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, > 0 indicates the interval at which it is sent.
+	IntervalUs int32  // The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, &gt; 0 indicates the interval at which it is sent.
 	MessageId  uint16 // The ID of the requested MAVLink message. v1.0 is limited to 254 messages.
 }
 
@@ -7707,7 +7703,7 @@ var DialectCommon *Dialect = &Dialect{
 		MSG_ID_GLOBAL_POSITION_INT:                     104,
 		MSG_ID_RC_CHANNELS_SCALED:                      237,
 		MSG_ID_RC_CHANNELS_RAW:                         244,
-		MSG_ID_SERVO_OUTPUT_RAW:                        175,
+		MSG_ID_SERVO_OUTPUT_RAW:                        222,
 		MSG_ID_MISSION_REQUEST_PARTIAL_LIST:            212,
 		MSG_ID_MISSION_WRITE_PARTIAL_LIST:              9,
 		MSG_ID_MISSION_ITEM:                            254,
@@ -7725,10 +7721,10 @@ var DialectCommon *Dialect = &Dialect{
 		MSG_ID_MISSION_REQUEST_INT:                     196,
 		MSG_ID_SAFETY_SET_ALLOWED_AREA:                 15,
 		MSG_ID_SAFETY_ALLOWED_AREA:                     3,
-		MSG_ID_ATTITUDE_QUATERNION_COV:                 153,
+		MSG_ID_ATTITUDE_QUATERNION_COV:                 167,
 		MSG_ID_NAV_CONTROLLER_OUTPUT:                   183,
-		MSG_ID_GLOBAL_POSITION_INT_COV:                 51,
-		MSG_ID_LOCAL_POSITION_NED_COV:                  59,
+		MSG_ID_GLOBAL_POSITION_INT_COV:                 119,
+		MSG_ID_LOCAL_POSITION_NED_COV:                  191,
 		MSG_ID_RC_CHANNELS:                             118,
 		MSG_ID_REQUEST_DATA_STREAM:                     148,
 		MSG_ID_DATA_STREAM:                             21,
@@ -7804,7 +7800,7 @@ var DialectCommon *Dialect = &Dialect{
 		MSG_ID_WIND_COV:                                105,
 		MSG_ID_GPS_INPUT:                               151,
 		MSG_ID_GPS_RTCM_DATA:                           35,
-		MSG_ID_HIGH_LATENCY:                            179,
+		MSG_ID_HIGH_LATENCY:                            150,
 		MSG_ID_VIBRATION:                               90,
 		MSG_ID_HOME_POSITION:                           104,
 		MSG_ID_SET_HOME_POSITION:                       85,

--- a/mavlink/common.go
+++ b/mavlink/common.go
@@ -33,7 +33,6 @@ const (
 	MAV_AUTOPILOT_ARMAZILA                                     = 15 // Armazila -- http://armazila.com
 	MAV_AUTOPILOT_AEROB                                        = 16 // Aerob -- http://aerob.ru
 	MAV_AUTOPILOT_ASLUAV                                       = 17 // ASLUAV autopilot -- http://www.asl.ethz.ch
-	MAV_AUTOPILOT_SMARTAP                                      = 18 // SmartAP Autopilot - http://sky-drones.com
 )
 
 // MavType:
@@ -139,8 +138,17 @@ const (
 // MavComponent:
 const (
 	MAV_COMP_ID_ALL            = 0   //
-	MAV_COMP_ID_AUTOPILOT1     = 1   //
+	MAV_COMP_ID_GPS            = 220 //
+	MAV_COMP_ID_MISSIONPLANNER = 190 //
+	MAV_COMP_ID_PATHPLANNER    = 195 //
+	MAV_COMP_ID_MAPPER         = 180 //
 	MAV_COMP_ID_CAMERA         = 100 //
+	MAV_COMP_ID_IMU            = 200 //
+	MAV_COMP_ID_IMU_2          = 201 //
+	MAV_COMP_ID_IMU_3          = 202 //
+	MAV_COMP_ID_UDP_BRIDGE     = 240 //
+	MAV_COMP_ID_UART_BRIDGE    = 241 //
+	MAV_COMP_ID_SYSTEM_CONTROL = 250 //
 	MAV_COMP_ID_SERVO1         = 140 //
 	MAV_COMP_ID_SERVO2         = 141 //
 	MAV_COMP_ID_SERVO3         = 142 //
@@ -161,17 +169,6 @@ const (
 	MAV_COMP_ID_OSD            = 157 // On Screen Display (OSD) devices for video links
 	MAV_COMP_ID_PERIPHERAL     = 158 // Generic autopilot peripheral component ID. Meant for devices that do not implement the parameter sub-protocol
 	MAV_COMP_ID_QX1_GIMBAL     = 159 //
-	MAV_COMP_ID_MAPPER         = 180 //
-	MAV_COMP_ID_MISSIONPLANNER = 190 //
-	MAV_COMP_ID_PATHPLANNER    = 195 //
-	MAV_COMP_ID_IMU            = 200 //
-	MAV_COMP_ID_IMU_2          = 201 //
-	MAV_COMP_ID_IMU_3          = 202 //
-	MAV_COMP_ID_GPS            = 220 //
-	MAV_COMP_ID_GPS2           = 221 //
-	MAV_COMP_ID_UDP_BRIDGE     = 240 //
-	MAV_COMP_ID_UART_BRIDGE    = 241 //
-	MAV_COMP_ID_SYSTEM_CONTROL = 250 //
 )
 
 // MavSysStatusSensor: These encode the sensors whose status is sent as part of the SYS_STATUS message.
@@ -201,7 +198,6 @@ const (
 	MAV_SYS_STATUS_TERRAIN                       = 4194304  // 0x400000 Terrain subsystem health
 	MAV_SYS_STATUS_REVERSE_MOTOR                 = 8388608  // 0x800000 Motors are reversed
 	MAV_SYS_STATUS_LOGGING                       = 16777216 // 0x1000000 Logging
-	MAV_SYS_STATUS_SENSOR_BATTERY                = 33554432 // 0x2000000 Battery
 )
 
 // MavFrame:
@@ -258,131 +254,109 @@ const (
 
 // MavCmd: Commands to be executed by the MAV. They can be executed on user request, or as part of a mission script. If the action is used in a mission, the parameter mapping to the waypoint/mission message is as follows: Param 1, Param 2, Param 3, Param 4, X: Param 5, Y:Param 6, Z:Param 7. This command list is similar what ARINC 424 is for commercial aircraft: A data format how to interpret waypoint/mission data.
 const (
-	MAV_CMD_NAV_WAYPOINT                       = 16    // Navigate to MISSION.
-	MAV_CMD_NAV_LOITER_UNLIM                   = 17    // Loiter around this MISSION an unlimited amount of time
-	MAV_CMD_NAV_LOITER_TURNS                   = 18    // Loiter around this MISSION for X turns
-	MAV_CMD_NAV_LOITER_TIME                    = 19    // Loiter around this MISSION for X seconds
-	MAV_CMD_NAV_RETURN_TO_LAUNCH               = 20    // Return to launch location
-	MAV_CMD_NAV_LAND                           = 21    // Land at location
-	MAV_CMD_NAV_TAKEOFF                        = 22    // Takeoff from ground / hand
-	MAV_CMD_NAV_LAND_LOCAL                     = 23    // Land at local position (local frame only)
-	MAV_CMD_NAV_TAKEOFF_LOCAL                  = 24    // Takeoff from local position (local frame only)
-	MAV_CMD_NAV_FOLLOW                         = 25    // Vehicle following, i.e. this waypoint represents the position of a moving vehicle
-	MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT        = 30    // Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.
-	MAV_CMD_NAV_LOITER_TO_ALT                  = 31    // Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint.
-	MAV_CMD_DO_FOLLOW                          = 32    // Being following a target
-	MAV_CMD_DO_FOLLOW_REPOSITION               = 33    // Reposition the MAV after a follow target command has been sent
-	MAV_CMD_NAV_ROI                            = 80    // Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.
-	MAV_CMD_NAV_PATHPLANNING                   = 81    // Control autonomous path planning on the MAV.
-	MAV_CMD_NAV_SPLINE_WAYPOINT                = 82    // Navigate to MISSION using a spline path.
-	MAV_CMD_NAV_VTOL_TAKEOFF                   = 84    // Takeoff from ground using VTOL mode
-	MAV_CMD_NAV_VTOL_LAND                      = 85    // Land using VTOL mode
-	MAV_CMD_NAV_GUIDED_ENABLE                  = 92    // hand control over to an external controller
-	MAV_CMD_NAV_DELAY                          = 93    // Delay the next navigation command a number of seconds or until a specified time
-	MAV_CMD_NAV_PAYLOAD_PLACE                  = 94    // Descend and place payload.  Vehicle descends until it detects a hanging payload has reached the ground, the gripper is opened to release the payload
-	MAV_CMD_NAV_LAST                           = 95    // NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration
-	MAV_CMD_CONDITION_DELAY                    = 112   // Delay mission state machine.
-	MAV_CMD_CONDITION_CHANGE_ALT               = 113   // Ascend/descend at rate.  Delay mission state machine until desired altitude reached.
-	MAV_CMD_CONDITION_DISTANCE                 = 114   // Delay mission state machine until within desired distance of next NAV point.
-	MAV_CMD_CONDITION_YAW                      = 115   // Reach a certain target angle.
-	MAV_CMD_CONDITION_LAST                     = 159   // NOP - This command is only used to mark the upper limit of the CONDITION commands in the enumeration
-	MAV_CMD_DO_SET_MODE                        = 176   // Set system mode.
-	MAV_CMD_DO_JUMP                            = 177   // Jump to the desired command in the mission list.  Repeat this action only the specified number of times
-	MAV_CMD_DO_CHANGE_SPEED                    = 178   // Change speed and/or throttle set points.
-	MAV_CMD_DO_SET_HOME                        = 179   // Changes the home location either to the current location or a specified location.
-	MAV_CMD_DO_SET_PARAMETER                   = 180   // Set a system parameter.  Caution!  Use of this command requires knowledge of the numeric enumeration value of the parameter.
-	MAV_CMD_DO_SET_RELAY                       = 181   // Set a relay to a condition.
-	MAV_CMD_DO_REPEAT_RELAY                    = 182   // Cycle a relay on and off for a desired number of cyles with a desired period.
-	MAV_CMD_DO_SET_SERVO                       = 183   // Set a servo to a desired PWM value.
-	MAV_CMD_DO_REPEAT_SERVO                    = 184   // Cycle a between its nominal setting and a desired PWM for a desired number of cycles with a desired period.
-	MAV_CMD_DO_FLIGHTTERMINATION               = 185   // Terminate flight immediately
-	MAV_CMD_DO_CHANGE_ALTITUDE                 = 186   // Change altitude set point.
-	MAV_CMD_DO_LAND_START                      = 189   // Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0 if not needed. If specified then it will be used to help find the closest landing sequence.
-	MAV_CMD_DO_RALLY_LAND                      = 190   // Mission command to perform a landing from a rally point.
-	MAV_CMD_DO_GO_AROUND                       = 191   // Mission command to safely abort an autonmous landing.
-	MAV_CMD_DO_REPOSITION                      = 192   // Reposition the vehicle to a specific WGS84 global position.
-	MAV_CMD_DO_PAUSE_CONTINUE                  = 193   // If in a GPS controlled position mode, hold the current position or continue.
-	MAV_CMD_DO_SET_REVERSE                     = 194   // Set moving direction to forward or reverse.
-	MAV_CMD_DO_CONTROL_VIDEO                   = 200   // Control onboard camera system.
-	MAV_CMD_DO_SET_ROI                         = 201   // Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.
-	MAV_CMD_DO_DIGICAM_CONFIGURE               = 202   // Mission command to configure an on-board camera controller system.
-	MAV_CMD_DO_DIGICAM_CONTROL                 = 203   // Mission command to control an on-board camera controller system.
-	MAV_CMD_DO_MOUNT_CONFIGURE                 = 204   // Mission command to configure a camera or antenna mount
-	MAV_CMD_DO_MOUNT_CONTROL                   = 205   // Mission command to control a camera or antenna mount
-	MAV_CMD_DO_SET_CAM_TRIGG_DIST              = 206   // Mission command to set camera trigger distance for this flight. The camera is trigerred each time this distance is exceeded. This command can also be used to set the shutter integration time for the camera.
-	MAV_CMD_DO_FENCE_ENABLE                    = 207   // Mission command to enable the geofence
-	MAV_CMD_DO_PARACHUTE                       = 208   // Mission command to trigger a parachute
-	MAV_CMD_DO_MOTOR_TEST                      = 209   // Mission command to perform motor test
-	MAV_CMD_DO_INVERTED_FLIGHT                 = 210   // Change to/from inverted flight
-	MAV_CMD_NAV_SET_YAW_SPEED                  = 213   // Sets a desired vehicle turn angle and speed change
-	MAV_CMD_DO_SET_CAM_TRIGG_INTERVAL          = 214   // Mission command to set camera trigger interval for this flight. If triggering is enabled, the camera is triggered each time this interval expires. This command can also be used to set the shutter integration time for the camera.
-	MAV_CMD_DO_MOUNT_CONTROL_QUAT              = 220   // Mission command to control a camera or antenna mount, using a quaternion as reference.
-	MAV_CMD_DO_GUIDED_MASTER                   = 221   // set id of master controller
-	MAV_CMD_DO_GUIDED_LIMITS                   = 222   // set limits for external control
-	MAV_CMD_DO_ENGINE_CONTROL                  = 223   // Control vehicle engine. This is interpreted by the vehicles engine controller to change the target engine state. It is intended for vehicles with internal combustion engines
-	MAV_CMD_DO_LAST                            = 240   // NOP - This command is only used to mark the upper limit of the DO commands in the enumeration
-	MAV_CMD_PREFLIGHT_CALIBRATION              = 241   // Trigger calibration. This command will be only accepted if in pre-flight mode. Except for Temperature Calibration, only one sensor should be set in a single message and all others should be zero.
-	MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS       = 242   // Set sensor offsets. This command will be only accepted if in pre-flight mode.
-	MAV_CMD_PREFLIGHT_UAVCAN                   = 243   // Trigger UAVCAN config. This command will be only accepted if in pre-flight mode.
-	MAV_CMD_PREFLIGHT_STORAGE                  = 245   // Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.
-	MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN          = 246   // Request the reboot or shutdown of system components.
-	MAV_CMD_OVERRIDE_GOTO                      = 252   // Hold / continue the current action
-	MAV_CMD_MISSION_START                      = 300   // start running a mission
-	MAV_CMD_COMPONENT_ARM_DISARM               = 400   // Arms / Disarms a component
-	MAV_CMD_GET_HOME_POSITION                  = 410   // Request the home position from the vehicle.
-	MAV_CMD_START_RX_PAIR                      = 500   // Starts receiver pairing
-	MAV_CMD_GET_MESSAGE_INTERVAL               = 510   // Request the interval between messages for a particular MAVLink message ID
-	MAV_CMD_SET_MESSAGE_INTERVAL               = 511   // Request the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM
-	MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES     = 520   // Request autopilot capabilities
-	MAV_CMD_REQUEST_CAMERA_INFORMATION         = 521   // WIP: Request camera information (CAMERA_INFORMATION)
-	MAV_CMD_REQUEST_CAMERA_SETTINGS            = 522   // WIP: Request camera settings (CAMERA_SETTINGS)
-	MAV_CMD_SET_CAMERA_SETTINGS_1              = 523   // WIP: Set the camera settings part 1 (CAMERA_SETTINGS). Use NAN for values you don't want to change.
-	MAV_CMD_SET_CAMERA_SETTINGS_2              = 524   // WIP: Set the camera settings part 2 (CAMERA_SETTINGS). Use NAN for values you don't want to change.
-	MAV_CMD_REQUEST_STORAGE_INFORMATION        = 525   // WIP: Request storage information (STORAGE_INFORMATION)
-	MAV_CMD_STORAGE_FORMAT                     = 526   // WIP: Format a storage medium
-	MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS      = 527   // WIP: Request camera capture status (CAMERA_CAPTURE_STATUS)
-	MAV_CMD_REQUEST_FLIGHT_INFORMATION         = 528   // WIP: Request flight information (FLIGHT_INFORMATION)
-	MAV_CMD_RESET_CAMERA_SETTINGS              = 529   // WIP: Reset all camera settings to Factory Default (CAMERA_SETTINGS)
-	MAV_CMD_SET_CAMERA_MODE                    = 530   // WIP: Set camera running mode. Use NAN for values you don't want to change.
-	MAV_CMD_IMAGE_START_CAPTURE                = 2000  // WIP: Start image capture sequence. Sends CAMERA_IMAGE_CAPTURED after each capture.
-	MAV_CMD_IMAGE_STOP_CAPTURE                 = 2001  // WIP: Stop image capture sequence
-	MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE       = 2002  // WIP: Re-request a CAMERA_IMAGE_CAPTURE packet
-	MAV_CMD_DO_TRIGGER_CONTROL                 = 2003  // Enable or disable on-board camera triggering system.
-	MAV_CMD_VIDEO_START_CAPTURE                = 2500  // WIP: Starts video capture (recording)
-	MAV_CMD_VIDEO_STOP_CAPTURE                 = 2501  // WIP: Stop the current video capture (recording)
-	MAV_CMD_VIDEO_START_STREAMING              = 2502  // WIP: Start video streaming
-	MAV_CMD_VIDEO_STOP_STREAMING               = 2503  // WIP: Stop the current video streaming
-	MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION   = 2504  // WIP: Request video stream information (VIDEO_STREAM_INFORMATION)
-	MAV_CMD_LOGGING_START                      = 2510  // Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)
-	MAV_CMD_LOGGING_STOP                       = 2511  // Request to stop streaming log data over MAVLink
-	MAV_CMD_AIRFRAME_CONFIGURATION             = 2520  //
-	MAV_CMD_PANORAMA_CREATE                    = 2800  // Create a panorama at the current position
-	MAV_CMD_DO_VTOL_TRANSITION                 = 3000  // Request VTOL transition
-	MAV_CMD_SET_GUIDED_SUBMODE_STANDARD        = 4000  // This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.
-	MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE          = 4001  // This command sets submode circle when vehicle is in guided mode. Vehicle flies along a circle facing the center of the circle. The user can input the velocity along the circle and change the radius. If no input is given the vehicle will hold position.
-	MAV_CMD_NAV_FENCE_RETURN_POINT             = 5000  // Fence return point. There can only be one fence return point.
-	MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION = 5001  // Fence vertex for an inclusion polygon (the polygon must not be self-intersecting). The vehicle must stay within this area. Minimum of 3 vertices required.
-	MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION = 5002  // Fence vertex for an exclusion polygon (the polygon must not be self-intersecting). The vehicle must stay outside this area. Minimum of 3 vertices required.
-	MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION         = 5003  // Circular fence area. The vehicle must stay inside this area.
-	MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION         = 5004  // Circular fence area. The vehicle must stay outside this area.
-	MAV_CMD_NAV_RALLY_POINT                    = 5100  // Rally point. You can have multiple rally points defined.
-	MAV_CMD_PAYLOAD_PREPARE_DEPLOY             = 30001 // Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity.
-	MAV_CMD_PAYLOAD_CONTROL_DEPLOY             = 30002 // Control the payload deployment.
-	MAV_CMD_WAYPOINT_USER_1                    = 31000 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
-	MAV_CMD_WAYPOINT_USER_2                    = 31001 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
-	MAV_CMD_WAYPOINT_USER_3                    = 31002 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
-	MAV_CMD_WAYPOINT_USER_4                    = 31003 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
-	MAV_CMD_WAYPOINT_USER_5                    = 31004 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
-	MAV_CMD_SPATIAL_USER_1                     = 31005 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
-	MAV_CMD_SPATIAL_USER_2                     = 31006 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
-	MAV_CMD_SPATIAL_USER_3                     = 31007 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
-	MAV_CMD_SPATIAL_USER_4                     = 31008 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
-	MAV_CMD_SPATIAL_USER_5                     = 31009 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
-	MAV_CMD_USER_1                             = 31010 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
-	MAV_CMD_USER_2                             = 31011 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
-	MAV_CMD_USER_3                             = 31012 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
-	MAV_CMD_USER_4                             = 31013 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
-	MAV_CMD_USER_5                             = 31014 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
+	MAV_CMD_NAV_WAYPOINT                   = 16    // Navigate to MISSION.
+	MAV_CMD_NAV_LOITER_UNLIM               = 17    // Loiter around this MISSION an unlimited amount of time
+	MAV_CMD_NAV_LOITER_TURNS               = 18    // Loiter around this MISSION for X turns
+	MAV_CMD_NAV_LOITER_TIME                = 19    // Loiter around this MISSION for X seconds
+	MAV_CMD_NAV_RETURN_TO_LAUNCH           = 20    // Return to launch location
+	MAV_CMD_NAV_LAND                       = 21    // Land at location
+	MAV_CMD_NAV_TAKEOFF                    = 22    // Takeoff from ground / hand
+	MAV_CMD_NAV_LAND_LOCAL                 = 23    // Land at local position (local frame only)
+	MAV_CMD_NAV_TAKEOFF_LOCAL              = 24    // Takeoff from local position (local frame only)
+	MAV_CMD_NAV_FOLLOW                     = 25    // Vehicle following, i.e. this waypoint represents the position of a moving vehicle
+	MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT    = 30    // Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.
+	MAV_CMD_NAV_LOITER_TO_ALT              = 31    // Begin loiter at the specified Latitude and Longitude.  If Lat=Lon=0, then loiter at the current position.  Don't consider the navigation command complete (don't leave loiter) until the altitude has been reached.  Additionally, if the Heading Required parameter is non-zero the  aircraft will not leave the loiter until heading toward the next waypoint.
+	MAV_CMD_DO_FOLLOW                      = 32    // Being following a target
+	MAV_CMD_DO_FOLLOW_REPOSITION           = 33    // Reposition the MAV after a follow target command has been sent
+	MAV_CMD_NAV_ROI                        = 80    // Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.
+	MAV_CMD_NAV_PATHPLANNING               = 81    // Control autonomous path planning on the MAV.
+	MAV_CMD_NAV_SPLINE_WAYPOINT            = 82    // Navigate to MISSION using a spline path.
+	MAV_CMD_NAV_VTOL_TAKEOFF               = 84    // Takeoff from ground using VTOL mode
+	MAV_CMD_NAV_VTOL_LAND                  = 85    // Land using VTOL mode
+	MAV_CMD_NAV_GUIDED_ENABLE              = 92    // hand control over to an external controller
+	MAV_CMD_NAV_DELAY                      = 93    // Delay the next navigation command a number of seconds or until a specified time
+	MAV_CMD_NAV_LAST                       = 95    // NOP - This command is only used to mark the upper limit of the NAV/ACTION commands in the enumeration
+	MAV_CMD_CONDITION_DELAY                = 112   // Delay mission state machine.
+	MAV_CMD_CONDITION_CHANGE_ALT           = 113   // Ascend/descend at rate.  Delay mission state machine until desired altitude reached.
+	MAV_CMD_CONDITION_DISTANCE             = 114   // Delay mission state machine until within desired distance of next NAV point.
+	MAV_CMD_CONDITION_YAW                  = 115   // Reach a certain target angle.
+	MAV_CMD_CONDITION_LAST                 = 159   // NOP - This command is only used to mark the upper limit of the CONDITION commands in the enumeration
+	MAV_CMD_DO_SET_MODE                    = 176   // Set system mode.
+	MAV_CMD_DO_JUMP                        = 177   // Jump to the desired command in the mission list.  Repeat this action only the specified number of times
+	MAV_CMD_DO_CHANGE_SPEED                = 178   // Change speed and/or throttle set points.
+	MAV_CMD_DO_SET_HOME                    = 179   // Changes the home location either to the current location or a specified location.
+	MAV_CMD_DO_SET_PARAMETER               = 180   // Set a system parameter.  Caution!  Use of this command requires knowledge of the numeric enumeration value of the parameter.
+	MAV_CMD_DO_SET_RELAY                   = 181   // Set a relay to a condition.
+	MAV_CMD_DO_REPEAT_RELAY                = 182   // Cycle a relay on and off for a desired number of cyles with a desired period.
+	MAV_CMD_DO_SET_SERVO                   = 183   // Set a servo to a desired PWM value.
+	MAV_CMD_DO_REPEAT_SERVO                = 184   // Cycle a between its nominal setting and a desired PWM for a desired number of cycles with a desired period.
+	MAV_CMD_DO_FLIGHTTERMINATION           = 185   // Terminate flight immediately
+	MAV_CMD_DO_CHANGE_ALTITUDE             = 186   // Change altitude set point.
+	MAV_CMD_DO_LAND_START                  = 189   // Mission command to perform a landing. This is used as a marker in a mission to tell the autopilot where a sequence of mission items that represents a landing starts. It may also be sent via a COMMAND_LONG to trigger a landing, in which case the nearest (geographically) landing sequence in the mission will be used. The Latitude/Longitude is optional, and may be set to 0/0 if not needed. If specified then it will be used to help find the closest landing sequence.
+	MAV_CMD_DO_RALLY_LAND                  = 190   // Mission command to perform a landing from a rally point.
+	MAV_CMD_DO_GO_AROUND                   = 191   // Mission command to safely abort an autonmous landing.
+	MAV_CMD_DO_REPOSITION                  = 192   // Reposition the vehicle to a specific WGS84 global position.
+	MAV_CMD_DO_PAUSE_CONTINUE              = 193   // If in a GPS controlled position mode, hold the current position or continue.
+	MAV_CMD_DO_SET_REVERSE                 = 194   // Set moving direction to forward or reverse.
+	MAV_CMD_DO_CONTROL_VIDEO               = 200   // Control onboard camera system.
+	MAV_CMD_DO_SET_ROI                     = 201   // Sets the region of interest (ROI) for a sensor set or the vehicle itself. This can then be used by the vehicles control system to control the vehicle attitude and the attitude of various sensors such as cameras.
+	MAV_CMD_DO_DIGICAM_CONFIGURE           = 202   // Mission command to configure an on-board camera controller system.
+	MAV_CMD_DO_DIGICAM_CONTROL             = 203   // Mission command to control an on-board camera controller system.
+	MAV_CMD_DO_MOUNT_CONFIGURE             = 204   // Mission command to configure a camera or antenna mount
+	MAV_CMD_DO_MOUNT_CONTROL               = 205   // Mission command to control a camera or antenna mount
+	MAV_CMD_DO_SET_CAM_TRIGG_DIST          = 206   // Mission command to set CAM_TRIGG_DIST for this flight
+	MAV_CMD_DO_FENCE_ENABLE                = 207   // Mission command to enable the geofence
+	MAV_CMD_DO_PARACHUTE                   = 208   // Mission command to trigger a parachute
+	MAV_CMD_DO_MOTOR_TEST                  = 209   // Mission command to perform motor test
+	MAV_CMD_DO_INVERTED_FLIGHT             = 210   // Change to/from inverted flight
+	MAV_CMD_DO_SET_POSITION_YAW_THRUST     = 213   // Sets a desired vehicle turn angle and thrust change
+	MAV_CMD_DO_MOUNT_CONTROL_QUAT          = 220   // Mission command to control a camera or antenna mount, using a quaternion as reference.
+	MAV_CMD_DO_GUIDED_MASTER               = 221   // set id of master controller
+	MAV_CMD_DO_GUIDED_LIMITS               = 222   // set limits for external control
+	MAV_CMD_DO_ENGINE_CONTROL              = 223   // Control vehicle engine. This is interpreted by the vehicles engine controller to change the target engine state. It is intended for vehicles with internal combustion engines
+	MAV_CMD_DO_LAST                        = 240   // NOP - This command is only used to mark the upper limit of the DO commands in the enumeration
+	MAV_CMD_PREFLIGHT_CALIBRATION          = 241   // Trigger calibration. This command will be only accepted if in pre-flight mode.
+	MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS   = 242   // Set sensor offsets. This command will be only accepted if in pre-flight mode.
+	MAV_CMD_PREFLIGHT_UAVCAN               = 243   // Trigger UAVCAN config. This command will be only accepted if in pre-flight mode.
+	MAV_CMD_PREFLIGHT_STORAGE              = 245   // Request storage of different parameter values and logs. This command will be only accepted if in pre-flight mode.
+	MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN      = 246   // Request the reboot or shutdown of system components.
+	MAV_CMD_OVERRIDE_GOTO                  = 252   // Hold / continue the current action
+	MAV_CMD_MISSION_START                  = 300   // start running a mission
+	MAV_CMD_COMPONENT_ARM_DISARM           = 400   // Arms / Disarms a component
+	MAV_CMD_GET_HOME_POSITION              = 410   // Request the home position from the vehicle.
+	MAV_CMD_START_RX_PAIR                  = 500   // Starts receiver pairing
+	MAV_CMD_GET_MESSAGE_INTERVAL           = 510   // Request the interval between messages for a particular MAVLink message ID
+	MAV_CMD_SET_MESSAGE_INTERVAL           = 511   // Request the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM
+	MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES = 520   // Request autopilot capabilities
+	MAV_CMD_IMAGE_START_CAPTURE            = 2000  // Start image capture sequence
+	MAV_CMD_IMAGE_STOP_CAPTURE             = 2001  // Stop image capture sequence
+	MAV_CMD_DO_TRIGGER_CONTROL             = 2003  // Enable or disable on-board camera triggering system.
+	MAV_CMD_VIDEO_START_CAPTURE            = 2500  // Starts video capture
+	MAV_CMD_VIDEO_STOP_CAPTURE             = 2501  // Stop the current video capture
+	MAV_CMD_LOGGING_START                  = 2510  // Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)
+	MAV_CMD_LOGGING_STOP                   = 2511  // Request to stop streaming log data over MAVLink
+	MAV_CMD_AIRFRAME_CONFIGURATION         = 2520  //
+	MAV_CMD_PANORAMA_CREATE                = 2800  // Create a panorama at the current position
+	MAV_CMD_DO_VTOL_TRANSITION             = 3000  // Request VTOL transition
+	MAV_CMD_SET_GUIDED_SUBMODE_STANDARD    = 4000  // This command sets the submode to standard guided when vehicle is in guided mode. The vehicle holds position and altitude and the user can input the desired velocites along all three axes.
+	MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE      = 4001  // This command sets submode circle when vehicle is in guided mode. Vehicle flies along a circle facing the center of the circle. The user can input the velocity along the circle and change the radius. If no input is given the vehicle will hold position.
+	MAV_CMD_PAYLOAD_PREPARE_DEPLOY         = 30001 // Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity.
+	MAV_CMD_PAYLOAD_CONTROL_DEPLOY         = 30002 // Control the payload deployment.
+	MAV_CMD_WAYPOINT_USER_1                = 31000 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
+	MAV_CMD_WAYPOINT_USER_2                = 31001 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
+	MAV_CMD_WAYPOINT_USER_3                = 31002 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
+	MAV_CMD_WAYPOINT_USER_4                = 31003 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
+	MAV_CMD_WAYPOINT_USER_5                = 31004 // User defined waypoint item. Ground Station will show the Vehicle as flying through this item.
+	MAV_CMD_SPATIAL_USER_1                 = 31005 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
+	MAV_CMD_SPATIAL_USER_2                 = 31006 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
+	MAV_CMD_SPATIAL_USER_3                 = 31007 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
+	MAV_CMD_SPATIAL_USER_4                 = 31008 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
+	MAV_CMD_SPATIAL_USER_5                 = 31009 // User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.
+	MAV_CMD_USER_1                         = 31010 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
+	MAV_CMD_USER_2                         = 31011 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
+	MAV_CMD_USER_3                         = 31012 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
+	MAV_CMD_USER_4                         = 31013 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
+	MAV_CMD_USER_5                         = 31014 // User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.
 )
 
 // MavDataStream: THIS INTERFACE IS DEPRECATED AS OF JULY 2015. Please use MESSAGE_INTERVAL instead. A data stream is not a fixed set of messages, but rather a      recommendation to the autopilot software. Individual autopilots may or may not obey      the recommended messages.
@@ -441,7 +415,6 @@ const (
 	MAV_RESULT_DENIED               = 2 // Command PERMANENTLY DENIED
 	MAV_RESULT_UNSUPPORTED          = 3 // Command UNKNOWN/UNSUPPORTED
 	MAV_RESULT_FAILED               = 4 // Command executed, but failed
-	MAV_RESULT_IN_PROGRESS          = 5 // WIP: Command being executed
 )
 
 // MavMissionResult: result in a mavlink mission ack
@@ -555,31 +528,20 @@ const (
 
 // MavProtocolCapability: Bitmask of (optional) autopilot capabilities (64 bit). If a bit is set, the autopilot supports this capability.
 const (
-	MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT                  = 1     // Autopilot supports MISSION float message type.
-	MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT                    = 2     // Autopilot supports the new param float message type.
-	MAV_PROTOCOL_CAPABILITY_MISSION_INT                    = 4     // Autopilot supports MISSION_INT scaled integer message type.
-	MAV_PROTOCOL_CAPABILITY_COMMAND_INT                    = 8     // Autopilot supports COMMAND_INT scaled integer message type.
-	MAV_PROTOCOL_CAPABILITY_PARAM_UNION                    = 16    // Autopilot supports the new param union message type.
-	MAV_PROTOCOL_CAPABILITY_FTP                            = 32    // Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.
-	MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET            = 64    // Autopilot supports commanding attitude offboard.
-	MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED  = 128   // Autopilot supports commanding position and velocity targets in local NED frame.
-	MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT = 256   // Autopilot supports commanding position and velocity targets in global scaled integers.
-	MAV_PROTOCOL_CAPABILITY_TERRAIN                        = 512   // Autopilot supports terrain protocol / data handling.
-	MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET            = 1024  // Autopilot supports direct actuator control.
-	MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION             = 2048  // Autopilot supports the flight termination command.
-	MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION            = 4096  // Autopilot supports onboard compass calibration.
-	MAV_PROTOCOL_CAPABILITY_MAVLINK2                       = 8192  // Autopilot supports mavlink version 2.
-	MAV_PROTOCOL_CAPABILITY_MISSION_FENCE                  = 16384 // Autopilot supports mission fence protocol.
-	MAV_PROTOCOL_CAPABILITY_MISSION_RALLY                  = 32768 // Autopilot supports mission rally point protocol.
-	MAV_PROTOCOL_CAPABILITY_FLIGHT_INFORMATION             = 65536 // Autopilot supports the flight information protocol.
-)
-
-// MavMissionType: Type of mission items being requested/sent in mission protocol.
-const (
-	MAV_MISSION_TYPE_MISSION = 0   // Items are mission commands for main mission.
-	MAV_MISSION_TYPE_FENCE   = 1   // Specifies GeoFence area(s). Items are MAV_CMD_FENCE_ GeoFence items.
-	MAV_MISSION_TYPE_RALLY   = 2   // Specifies the rally points for the vehicle. Rally points are alternative RTL points. Items are MAV_CMD_RALLY_POINT rally point items.
-	MAV_MISSION_TYPE_ALL     = 255 // Only used in MISSION_CLEAR_ALL to clear all mission types.
+	MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT                  = 1    // Autopilot supports MISSION float message type.
+	MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT                    = 2    // Autopilot supports the new param float message type.
+	MAV_PROTOCOL_CAPABILITY_MISSION_INT                    = 4    // Autopilot supports MISSION_INT scaled integer message type.
+	MAV_PROTOCOL_CAPABILITY_COMMAND_INT                    = 8    // Autopilot supports COMMAND_INT scaled integer message type.
+	MAV_PROTOCOL_CAPABILITY_PARAM_UNION                    = 16   // Autopilot supports the new param union message type.
+	MAV_PROTOCOL_CAPABILITY_FTP                            = 32   // Autopilot supports the new FILE_TRANSFER_PROTOCOL message type.
+	MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET            = 64   // Autopilot supports commanding attitude offboard.
+	MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED  = 128  // Autopilot supports commanding position and velocity targets in local NED frame.
+	MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT = 256  // Autopilot supports commanding position and velocity targets in global scaled integers.
+	MAV_PROTOCOL_CAPABILITY_TERRAIN                        = 512  // Autopilot supports terrain protocol / data handling.
+	MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET            = 1024 // Autopilot supports direct actuator control.
+	MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION             = 2048 // Autopilot supports the flight termination command.
+	MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION            = 4096 // Autopilot supports onboard compass calibration.
+	MAV_PROTOCOL_CAPABILITY_MAVLINK2                       = 8192 // Autopilot supports mavlink version 2.
 )
 
 // MavEstimatorType: Enumeration of estimator types
@@ -623,8 +585,6 @@ const (
 	MAV_LANDED_STATE_UNDEFINED = 0 // MAV landed state is unknown
 	MAV_LANDED_STATE_ON_GROUND = 1 // MAV is landed (on ground)
 	MAV_LANDED_STATE_IN_AIR    = 2 // MAV is in air
-	MAV_LANDED_STATE_TAKEOFF   = 3 // MAV currently taking off
-	MAV_LANDED_STATE_LANDING   = 4 // MAV currently landing
 )
 
 // AdsbAltitudeType: Enumeration of the ADSB altimeter types
@@ -711,8 +671,8 @@ const (
 const (
 	MAV_COLLISION_ACTION_NONE               = 0 // Ignore any potential collisions
 	MAV_COLLISION_ACTION_REPORT             = 1 // Report potential collision
-	MAV_COLLISION_ACTION_ASCEND_OR_DESCEND  = 2 // Ascend or Descend to avoid threat
-	MAV_COLLISION_ACTION_MOVE_HORIZONTALLY  = 3 // Move horizontally to avoid threat
+	MAV_COLLISION_ACTION_ASCEND_OR_DESCEND  = 2 // Ascend or Descend to avoid thread
+	MAV_COLLISION_ACTION_MOVE_HORIZONTALLY  = 3 // Ascend or Descend to avoid thread
 	MAV_COLLISION_ACTION_MOVE_PERPENDICULAR = 4 // Aircraft to move perpendicular to the collision's velocity vector
 	MAV_COLLISION_ACTION_RTL                = 5 // Aircraft to fly directly back to its launch point
 	MAV_COLLISION_ACTION_HOVER              = 6 // Aircraft to stop in place
@@ -1930,7 +1890,6 @@ type MissionRequestPartialList struct {
 	EndIndex        int16 // End index, -1 by default (-1: send list to end). Else a valid index of the list
 	TargetSystem    uint8 // System ID
 	TargetComponent uint8 // Component ID
-	MissionType     uint8 // Mission type, see MAV_MISSION_TYPE
 }
 
 func (self *MissionRequestPartialList) MsgID() MessageID {
@@ -1942,12 +1901,11 @@ func (self *MissionRequestPartialList) MsgName() string {
 }
 
 func (self *MissionRequestPartialList) Pack(p *Packet) error {
-	payload := make([]byte, 7)
+	payload := make([]byte, 6)
 	binary.LittleEndian.PutUint16(payload[0:], uint16(self.StartIndex))
 	binary.LittleEndian.PutUint16(payload[2:], uint16(self.EndIndex))
 	payload[4] = byte(self.TargetSystem)
 	payload[5] = byte(self.TargetComponent)
-	payload[6] = byte(self.MissionType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -1955,14 +1913,13 @@ func (self *MissionRequestPartialList) Pack(p *Packet) error {
 }
 
 func (self *MissionRequestPartialList) Unpack(p *Packet) error {
-	if len(p.Payload) < 7 {
+	if len(p.Payload) < 6 {
 		return fmt.Errorf("payload too small")
 	}
 	self.StartIndex = int16(binary.LittleEndian.Uint16(p.Payload[0:]))
 	self.EndIndex = int16(binary.LittleEndian.Uint16(p.Payload[2:]))
 	self.TargetSystem = uint8(p.Payload[4])
 	self.TargetComponent = uint8(p.Payload[5])
-	self.MissionType = uint8(p.Payload[6])
 	return nil
 }
 
@@ -1972,7 +1929,6 @@ type MissionWritePartialList struct {
 	EndIndex        int16 // End index, equal or greater than start index.
 	TargetSystem    uint8 // System ID
 	TargetComponent uint8 // Component ID
-	MissionType     uint8 // Mission type, see MAV_MISSION_TYPE
 }
 
 func (self *MissionWritePartialList) MsgID() MessageID {
@@ -1984,12 +1940,11 @@ func (self *MissionWritePartialList) MsgName() string {
 }
 
 func (self *MissionWritePartialList) Pack(p *Packet) error {
-	payload := make([]byte, 7)
+	payload := make([]byte, 6)
 	binary.LittleEndian.PutUint16(payload[0:], uint16(self.StartIndex))
 	binary.LittleEndian.PutUint16(payload[2:], uint16(self.EndIndex))
 	payload[4] = byte(self.TargetSystem)
 	payload[5] = byte(self.TargetComponent)
-	payload[6] = byte(self.MissionType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -1997,14 +1952,13 @@ func (self *MissionWritePartialList) Pack(p *Packet) error {
 }
 
 func (self *MissionWritePartialList) Unpack(p *Packet) error {
-	if len(p.Payload) < 7 {
+	if len(p.Payload) < 6 {
 		return fmt.Errorf("payload too small")
 	}
 	self.StartIndex = int16(binary.LittleEndian.Uint16(p.Payload[0:]))
 	self.EndIndex = int16(binary.LittleEndian.Uint16(p.Payload[2:]))
 	self.TargetSystem = uint8(p.Payload[4])
 	self.TargetComponent = uint8(p.Payload[5])
-	self.MissionType = uint8(p.Payload[6])
 	return nil
 }
 
@@ -2025,7 +1979,6 @@ type MissionItem struct {
 	Frame           uint8   // The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h
 	Current         uint8   // false:0, true:1
 	Autocontinue    uint8   // autocontinue to next wp
-	MissionType     uint8   // Mission type, see MAV_MISSION_TYPE
 }
 
 func (self *MissionItem) MsgID() MessageID {
@@ -2037,7 +1990,7 @@ func (self *MissionItem) MsgName() string {
 }
 
 func (self *MissionItem) Pack(p *Packet) error {
-	payload := make([]byte, 38)
+	payload := make([]byte, 37)
 	binary.LittleEndian.PutUint32(payload[0:], math.Float32bits(self.Param1))
 	binary.LittleEndian.PutUint32(payload[4:], math.Float32bits(self.Param2))
 	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.Param3))
@@ -2052,7 +2005,6 @@ func (self *MissionItem) Pack(p *Packet) error {
 	payload[34] = byte(self.Frame)
 	payload[35] = byte(self.Current)
 	payload[36] = byte(self.Autocontinue)
-	payload[37] = byte(self.MissionType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2060,7 +2012,7 @@ func (self *MissionItem) Pack(p *Packet) error {
 }
 
 func (self *MissionItem) Unpack(p *Packet) error {
-	if len(p.Payload) < 38 {
+	if len(p.Payload) < 37 {
 		return fmt.Errorf("payload too small")
 	}
 	self.Param1 = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[0:]))
@@ -2077,7 +2029,6 @@ func (self *MissionItem) Unpack(p *Packet) error {
 	self.Frame = uint8(p.Payload[34])
 	self.Current = uint8(p.Payload[35])
 	self.Autocontinue = uint8(p.Payload[36])
-	self.MissionType = uint8(p.Payload[37])
 	return nil
 }
 
@@ -2086,7 +2037,6 @@ type MissionRequest struct {
 	Seq             uint16 // Sequence
 	TargetSystem    uint8  // System ID
 	TargetComponent uint8  // Component ID
-	MissionType     uint8  // Mission type, see MAV_MISSION_TYPE
 }
 
 func (self *MissionRequest) MsgID() MessageID {
@@ -2098,11 +2048,10 @@ func (self *MissionRequest) MsgName() string {
 }
 
 func (self *MissionRequest) Pack(p *Packet) error {
-	payload := make([]byte, 5)
+	payload := make([]byte, 4)
 	binary.LittleEndian.PutUint16(payload[0:], uint16(self.Seq))
 	payload[2] = byte(self.TargetSystem)
 	payload[3] = byte(self.TargetComponent)
-	payload[4] = byte(self.MissionType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2110,13 +2059,12 @@ func (self *MissionRequest) Pack(p *Packet) error {
 }
 
 func (self *MissionRequest) Unpack(p *Packet) error {
-	if len(p.Payload) < 5 {
+	if len(p.Payload) < 4 {
 		return fmt.Errorf("payload too small")
 	}
 	self.Seq = uint16(binary.LittleEndian.Uint16(p.Payload[0:]))
 	self.TargetSystem = uint8(p.Payload[2])
 	self.TargetComponent = uint8(p.Payload[3])
-	self.MissionType = uint8(p.Payload[4])
 	return nil
 }
 
@@ -2190,7 +2138,6 @@ func (self *MissionCurrent) Unpack(p *Packet) error {
 type MissionRequestList struct {
 	TargetSystem    uint8 // System ID
 	TargetComponent uint8 // Component ID
-	MissionType     uint8 // Mission type, see MAV_MISSION_TYPE
 }
 
 func (self *MissionRequestList) MsgID() MessageID {
@@ -2202,10 +2149,9 @@ func (self *MissionRequestList) MsgName() string {
 }
 
 func (self *MissionRequestList) Pack(p *Packet) error {
-	payload := make([]byte, 3)
+	payload := make([]byte, 2)
 	payload[0] = byte(self.TargetSystem)
 	payload[1] = byte(self.TargetComponent)
-	payload[2] = byte(self.MissionType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2213,12 +2159,11 @@ func (self *MissionRequestList) Pack(p *Packet) error {
 }
 
 func (self *MissionRequestList) Unpack(p *Packet) error {
-	if len(p.Payload) < 3 {
+	if len(p.Payload) < 2 {
 		return fmt.Errorf("payload too small")
 	}
 	self.TargetSystem = uint8(p.Payload[0])
 	self.TargetComponent = uint8(p.Payload[1])
-	self.MissionType = uint8(p.Payload[2])
 	return nil
 }
 
@@ -2227,7 +2172,6 @@ type MissionCount struct {
 	Count           uint16 // Number of mission items in the sequence
 	TargetSystem    uint8  // System ID
 	TargetComponent uint8  // Component ID
-	MissionType     uint8  // Mission type, see MAV_MISSION_TYPE
 }
 
 func (self *MissionCount) MsgID() MessageID {
@@ -2239,11 +2183,10 @@ func (self *MissionCount) MsgName() string {
 }
 
 func (self *MissionCount) Pack(p *Packet) error {
-	payload := make([]byte, 5)
+	payload := make([]byte, 4)
 	binary.LittleEndian.PutUint16(payload[0:], uint16(self.Count))
 	payload[2] = byte(self.TargetSystem)
 	payload[3] = byte(self.TargetComponent)
-	payload[4] = byte(self.MissionType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2251,13 +2194,12 @@ func (self *MissionCount) Pack(p *Packet) error {
 }
 
 func (self *MissionCount) Unpack(p *Packet) error {
-	if len(p.Payload) < 5 {
+	if len(p.Payload) < 4 {
 		return fmt.Errorf("payload too small")
 	}
 	self.Count = uint16(binary.LittleEndian.Uint16(p.Payload[0:]))
 	self.TargetSystem = uint8(p.Payload[2])
 	self.TargetComponent = uint8(p.Payload[3])
-	self.MissionType = uint8(p.Payload[4])
 	return nil
 }
 
@@ -2265,7 +2207,6 @@ func (self *MissionCount) Unpack(p *Packet) error {
 type MissionClearAll struct {
 	TargetSystem    uint8 // System ID
 	TargetComponent uint8 // Component ID
-	MissionType     uint8 // Mission type, see MAV_MISSION_TYPE
 }
 
 func (self *MissionClearAll) MsgID() MessageID {
@@ -2277,10 +2218,9 @@ func (self *MissionClearAll) MsgName() string {
 }
 
 func (self *MissionClearAll) Pack(p *Packet) error {
-	payload := make([]byte, 3)
+	payload := make([]byte, 2)
 	payload[0] = byte(self.TargetSystem)
 	payload[1] = byte(self.TargetComponent)
-	payload[2] = byte(self.MissionType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2288,12 +2228,11 @@ func (self *MissionClearAll) Pack(p *Packet) error {
 }
 
 func (self *MissionClearAll) Unpack(p *Packet) error {
-	if len(p.Payload) < 3 {
+	if len(p.Payload) < 2 {
 		return fmt.Errorf("payload too small")
 	}
 	self.TargetSystem = uint8(p.Payload[0])
 	self.TargetComponent = uint8(p.Payload[1])
-	self.MissionType = uint8(p.Payload[2])
 	return nil
 }
 
@@ -2332,7 +2271,6 @@ type MissionAck struct {
 	TargetSystem    uint8 // System ID
 	TargetComponent uint8 // Component ID
 	Type            uint8 // See MAV_MISSION_RESULT enum
-	MissionType     uint8 // Mission type, see MAV_MISSION_TYPE
 }
 
 func (self *MissionAck) MsgID() MessageID {
@@ -2344,11 +2282,10 @@ func (self *MissionAck) MsgName() string {
 }
 
 func (self *MissionAck) Pack(p *Packet) error {
-	payload := make([]byte, 4)
+	payload := make([]byte, 3)
 	payload[0] = byte(self.TargetSystem)
 	payload[1] = byte(self.TargetComponent)
 	payload[2] = byte(self.Type)
-	payload[3] = byte(self.MissionType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2356,13 +2293,12 @@ func (self *MissionAck) Pack(p *Packet) error {
 }
 
 func (self *MissionAck) Unpack(p *Packet) error {
-	if len(p.Payload) < 4 {
+	if len(p.Payload) < 3 {
 		return fmt.Errorf("payload too small")
 	}
 	self.TargetSystem = uint8(p.Payload[0])
 	self.TargetComponent = uint8(p.Payload[1])
 	self.Type = uint8(p.Payload[2])
-	self.MissionType = uint8(p.Payload[3])
 	return nil
 }
 
@@ -2500,7 +2436,6 @@ type MissionRequestInt struct {
 	Seq             uint16 // Sequence
 	TargetSystem    uint8  // System ID
 	TargetComponent uint8  // Component ID
-	MissionType     uint8  // Mission type, see MAV_MISSION_TYPE
 }
 
 func (self *MissionRequestInt) MsgID() MessageID {
@@ -2512,11 +2447,10 @@ func (self *MissionRequestInt) MsgName() string {
 }
 
 func (self *MissionRequestInt) Pack(p *Packet) error {
-	payload := make([]byte, 5)
+	payload := make([]byte, 4)
 	binary.LittleEndian.PutUint16(payload[0:], uint16(self.Seq))
 	payload[2] = byte(self.TargetSystem)
 	payload[3] = byte(self.TargetComponent)
-	payload[4] = byte(self.MissionType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2524,13 +2458,12 @@ func (self *MissionRequestInt) Pack(p *Packet) error {
 }
 
 func (self *MissionRequestInt) Unpack(p *Packet) error {
-	if len(p.Payload) < 5 {
+	if len(p.Payload) < 4 {
 		return fmt.Errorf("payload too small")
 	}
 	self.Seq = uint16(binary.LittleEndian.Uint16(p.Payload[0:]))
 	self.TargetSystem = uint8(p.Payload[2])
 	self.TargetComponent = uint8(p.Payload[3])
-	self.MissionType = uint8(p.Payload[4])
 	return nil
 }
 
@@ -2638,7 +2571,7 @@ func (self *SafetyAllowedArea) Unpack(p *Packet) error {
 
 // The attitude in the aeronautical frame (right-handed, Z-down, X-front, Y-right), expressed as quaternion. Quaternion order is w, x, y, z and a zero rotation would be expressed as (1 0 0 0).
 type AttitudeQuaternionCov struct {
-	TimeUsec   uint64     // Timestamp (microseconds since system boot or since UNIX epoch)
+	TimeBootMs uint32     // Timestamp (milliseconds since system boot)
 	Q          [4]float32 // Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)
 	Rollspeed  float32    // Roll angular speed (rad/s)
 	Pitchspeed float32    // Pitch angular speed (rad/s)
@@ -2655,16 +2588,16 @@ func (self *AttitudeQuaternionCov) MsgName() string {
 }
 
 func (self *AttitudeQuaternionCov) Pack(p *Packet) error {
-	payload := make([]byte, 72)
-	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUsec))
+	payload := make([]byte, 68)
+	binary.LittleEndian.PutUint32(payload[0:], uint32(self.TimeBootMs))
 	for i, v := range self.Q {
-		binary.LittleEndian.PutUint32(payload[8+i*4:], math.Float32bits(v))
+		binary.LittleEndian.PutUint32(payload[4+i*4:], math.Float32bits(v))
 	}
-	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.Rollspeed))
-	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Pitchspeed))
-	binary.LittleEndian.PutUint32(payload[32:], math.Float32bits(self.Yawspeed))
+	binary.LittleEndian.PutUint32(payload[20:], math.Float32bits(self.Rollspeed))
+	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.Pitchspeed))
+	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Yawspeed))
 	for i, v := range self.Covariance {
-		binary.LittleEndian.PutUint32(payload[36+i*4:], math.Float32bits(v))
+		binary.LittleEndian.PutUint32(payload[32+i*4:], math.Float32bits(v))
 	}
 
 	p.MsgID = self.MsgID()
@@ -2673,18 +2606,18 @@ func (self *AttitudeQuaternionCov) Pack(p *Packet) error {
 }
 
 func (self *AttitudeQuaternionCov) Unpack(p *Packet) error {
-	if len(p.Payload) < 72 {
+	if len(p.Payload) < 68 {
 		return fmt.Errorf("payload too small")
 	}
-	self.TimeUsec = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
+	self.TimeBootMs = uint32(binary.LittleEndian.Uint32(p.Payload[0:]))
 	for i := 0; i < len(self.Q); i++ {
-		self.Q[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8+i*4:]))
+		self.Q[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[4+i*4:]))
 	}
-	self.Rollspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
-	self.Pitchspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
-	self.Yawspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32:]))
+	self.Rollspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[20:]))
+	self.Pitchspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
+	self.Yawspeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
 	for i := 0; i < len(self.Covariance); i++ {
-		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[36+i*4:]))
+		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32+i*4:]))
 	}
 	return nil
 }
@@ -2742,7 +2675,8 @@ func (self *NavControllerOutput) Unpack(p *Packet) error {
 
 // The filtered global position (e.g. fused GPS and accelerometers). The position is in GPS-frame (right-handed, Z-up). It  is designed as scaled integer message since the resolution of float is not sufficient. NOTE: This message is intended for onboard networks / companion computers and higher-bandwidth links and optimized for accuracy and completeness. Please use the GLOBAL_POSITION_INT message for a minimal subset.
 type GlobalPositionIntCov struct {
-	TimeUsec      uint64      // Timestamp (microseconds since system boot or since UNIX epoch)
+	TimeUtc       uint64      // Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown. Commonly filled by the precision time source of a GPS receiver.
+	TimeBootMs    uint32      // Timestamp (milliseconds since system boot)
 	Lat           int32       // Latitude, expressed as degrees * 1E7
 	Lon           int32       // Longitude, expressed as degrees * 1E7
 	Alt           int32       // Altitude in meters, expressed as * 1000 (millimeters), above MSL
@@ -2763,19 +2697,20 @@ func (self *GlobalPositionIntCov) MsgName() string {
 }
 
 func (self *GlobalPositionIntCov) Pack(p *Packet) error {
-	payload := make([]byte, 181)
-	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUsec))
-	binary.LittleEndian.PutUint32(payload[8:], uint32(self.Lat))
-	binary.LittleEndian.PutUint32(payload[12:], uint32(self.Lon))
-	binary.LittleEndian.PutUint32(payload[16:], uint32(self.Alt))
-	binary.LittleEndian.PutUint32(payload[20:], uint32(self.RelativeAlt))
-	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.Vx))
-	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Vy))
-	binary.LittleEndian.PutUint32(payload[32:], math.Float32bits(self.Vz))
+	payload := make([]byte, 185)
+	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUtc))
+	binary.LittleEndian.PutUint32(payload[8:], uint32(self.TimeBootMs))
+	binary.LittleEndian.PutUint32(payload[12:], uint32(self.Lat))
+	binary.LittleEndian.PutUint32(payload[16:], uint32(self.Lon))
+	binary.LittleEndian.PutUint32(payload[20:], uint32(self.Alt))
+	binary.LittleEndian.PutUint32(payload[24:], uint32(self.RelativeAlt))
+	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Vx))
+	binary.LittleEndian.PutUint32(payload[32:], math.Float32bits(self.Vy))
+	binary.LittleEndian.PutUint32(payload[36:], math.Float32bits(self.Vz))
 	for i, v := range self.Covariance {
-		binary.LittleEndian.PutUint32(payload[36+i*4:], math.Float32bits(v))
+		binary.LittleEndian.PutUint32(payload[40+i*4:], math.Float32bits(v))
 	}
-	payload[180] = byte(self.EstimatorType)
+	payload[184] = byte(self.EstimatorType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2783,27 +2718,29 @@ func (self *GlobalPositionIntCov) Pack(p *Packet) error {
 }
 
 func (self *GlobalPositionIntCov) Unpack(p *Packet) error {
-	if len(p.Payload) < 181 {
+	if len(p.Payload) < 185 {
 		return fmt.Errorf("payload too small")
 	}
-	self.TimeUsec = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
-	self.Lat = int32(binary.LittleEndian.Uint32(p.Payload[8:]))
-	self.Lon = int32(binary.LittleEndian.Uint32(p.Payload[12:]))
-	self.Alt = int32(binary.LittleEndian.Uint32(p.Payload[16:]))
-	self.RelativeAlt = int32(binary.LittleEndian.Uint32(p.Payload[20:]))
-	self.Vx = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
-	self.Vy = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
-	self.Vz = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32:]))
+	self.TimeUtc = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
+	self.TimeBootMs = uint32(binary.LittleEndian.Uint32(p.Payload[8:]))
+	self.Lat = int32(binary.LittleEndian.Uint32(p.Payload[12:]))
+	self.Lon = int32(binary.LittleEndian.Uint32(p.Payload[16:]))
+	self.Alt = int32(binary.LittleEndian.Uint32(p.Payload[20:]))
+	self.RelativeAlt = int32(binary.LittleEndian.Uint32(p.Payload[24:]))
+	self.Vx = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
+	self.Vy = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32:]))
+	self.Vz = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[36:]))
 	for i := 0; i < len(self.Covariance); i++ {
-		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[36+i*4:]))
+		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[40+i*4:]))
 	}
-	self.EstimatorType = uint8(p.Payload[180])
+	self.EstimatorType = uint8(p.Payload[184])
 	return nil
 }
 
 // The filtered local position (e.g. fused computer vision and accelerometers). Coordinate frame is right-handed, Z-axis down (aeronautical frame, NED / north-east-down convention)
 type LocalPositionNedCov struct {
-	TimeUsec      uint64      // Timestamp (microseconds since system boot or since UNIX epoch)
+	TimeUtc       uint64      // Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown. Commonly filled by the precision time source of a GPS receiver.
+	TimeBootMs    uint32      // Timestamp (milliseconds since system boot). 0 for system without monotonic timestamp
 	X             float32     // X Position
 	Y             float32     // Y Position
 	Z             float32     // Z Position
@@ -2826,21 +2763,22 @@ func (self *LocalPositionNedCov) MsgName() string {
 }
 
 func (self *LocalPositionNedCov) Pack(p *Packet) error {
-	payload := make([]byte, 225)
-	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUsec))
-	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.X))
-	binary.LittleEndian.PutUint32(payload[12:], math.Float32bits(self.Y))
-	binary.LittleEndian.PutUint32(payload[16:], math.Float32bits(self.Z))
-	binary.LittleEndian.PutUint32(payload[20:], math.Float32bits(self.Vx))
-	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.Vy))
-	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Vz))
-	binary.LittleEndian.PutUint32(payload[32:], math.Float32bits(self.Ax))
-	binary.LittleEndian.PutUint32(payload[36:], math.Float32bits(self.Ay))
-	binary.LittleEndian.PutUint32(payload[40:], math.Float32bits(self.Az))
+	payload := make([]byte, 229)
+	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUtc))
+	binary.LittleEndian.PutUint32(payload[8:], uint32(self.TimeBootMs))
+	binary.LittleEndian.PutUint32(payload[12:], math.Float32bits(self.X))
+	binary.LittleEndian.PutUint32(payload[16:], math.Float32bits(self.Y))
+	binary.LittleEndian.PutUint32(payload[20:], math.Float32bits(self.Z))
+	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.Vx))
+	binary.LittleEndian.PutUint32(payload[28:], math.Float32bits(self.Vy))
+	binary.LittleEndian.PutUint32(payload[32:], math.Float32bits(self.Vz))
+	binary.LittleEndian.PutUint32(payload[36:], math.Float32bits(self.Ax))
+	binary.LittleEndian.PutUint32(payload[40:], math.Float32bits(self.Ay))
+	binary.LittleEndian.PutUint32(payload[44:], math.Float32bits(self.Az))
 	for i, v := range self.Covariance {
-		binary.LittleEndian.PutUint32(payload[44+i*4:], math.Float32bits(v))
+		binary.LittleEndian.PutUint32(payload[48+i*4:], math.Float32bits(v))
 	}
-	payload[224] = byte(self.EstimatorType)
+	payload[228] = byte(self.EstimatorType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -2848,23 +2786,24 @@ func (self *LocalPositionNedCov) Pack(p *Packet) error {
 }
 
 func (self *LocalPositionNedCov) Unpack(p *Packet) error {
-	if len(p.Payload) < 225 {
+	if len(p.Payload) < 229 {
 		return fmt.Errorf("payload too small")
 	}
-	self.TimeUsec = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
-	self.X = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8:]))
-	self.Y = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[12:]))
-	self.Z = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[16:]))
-	self.Vx = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[20:]))
-	self.Vy = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
-	self.Vz = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
-	self.Ax = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32:]))
-	self.Ay = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[36:]))
-	self.Az = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[40:]))
+	self.TimeUtc = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
+	self.TimeBootMs = uint32(binary.LittleEndian.Uint32(p.Payload[8:]))
+	self.X = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[12:]))
+	self.Y = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[16:]))
+	self.Z = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[20:]))
+	self.Vx = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
+	self.Vy = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[28:]))
+	self.Vz = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[32:]))
+	self.Ax = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[36:]))
+	self.Ay = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[40:]))
+	self.Az = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[44:]))
 	for i := 0; i < len(self.Covariance); i++ {
-		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[44+i*4:]))
+		self.Covariance[i] = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[48+i*4:]))
 	}
-	self.EstimatorType = uint8(p.Payload[224])
+	self.EstimatorType = uint8(p.Payload[228])
 	return nil
 }
 
@@ -3155,7 +3094,6 @@ type MissionItemInt struct {
 	Frame           uint8   // The coordinate system of the MISSION. see MAV_FRAME in mavlink_types.h
 	Current         uint8   // false:0, true:1
 	Autocontinue    uint8   // autocontinue to next wp
-	MissionType     uint8   // Mission type, see MAV_MISSION_TYPE
 }
 
 func (self *MissionItemInt) MsgID() MessageID {
@@ -3167,7 +3105,7 @@ func (self *MissionItemInt) MsgName() string {
 }
 
 func (self *MissionItemInt) Pack(p *Packet) error {
-	payload := make([]byte, 38)
+	payload := make([]byte, 37)
 	binary.LittleEndian.PutUint32(payload[0:], math.Float32bits(self.Param1))
 	binary.LittleEndian.PutUint32(payload[4:], math.Float32bits(self.Param2))
 	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.Param3))
@@ -3182,7 +3120,6 @@ func (self *MissionItemInt) Pack(p *Packet) error {
 	payload[34] = byte(self.Frame)
 	payload[35] = byte(self.Current)
 	payload[36] = byte(self.Autocontinue)
-	payload[37] = byte(self.MissionType)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -3190,7 +3127,7 @@ func (self *MissionItemInt) Pack(p *Packet) error {
 }
 
 func (self *MissionItemInt) Unpack(p *Packet) error {
-	if len(p.Payload) < 38 {
+	if len(p.Payload) < 37 {
 		return fmt.Errorf("payload too small")
 	}
 	self.Param1 = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[0:]))
@@ -3207,7 +3144,6 @@ func (self *MissionItemInt) Unpack(p *Packet) error {
 	self.Frame = uint8(p.Payload[34])
 	self.Current = uint8(p.Payload[35])
 	self.Autocontinue = uint8(p.Payload[36])
-	self.MissionType = uint8(p.Payload[37])
 	return nil
 }
 
@@ -3384,9 +3320,8 @@ func (self *CommandLong) Unpack(p *Packet) error {
 
 // Report status of a command. Includes feedback wether the command was executed.
 type CommandAck struct {
-	Command  uint16 // Command ID, as defined by MAV_CMD enum.
-	Result   uint8  // See MAV_RESULT enum
-	Progress uint8  // WIP: Needs to be set when MAV_RESULT is MAV_RESULT_IN_PROGRESS, values from 0 to 100 for progress percentage, 255 for unknown progress.
+	Command uint16 // Command ID, as defined by MAV_CMD enum.
+	Result  uint8  // See MAV_RESULT enum
 }
 
 func (self *CommandAck) MsgID() MessageID {
@@ -3398,10 +3333,9 @@ func (self *CommandAck) MsgName() string {
 }
 
 func (self *CommandAck) Pack(p *Packet) error {
-	payload := make([]byte, 4)
+	payload := make([]byte, 3)
 	binary.LittleEndian.PutUint16(payload[0:], uint16(self.Command))
 	payload[2] = byte(self.Result)
-	payload[3] = byte(self.Progress)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -3409,12 +3343,11 @@ func (self *CommandAck) Pack(p *Packet) error {
 }
 
 func (self *CommandAck) Unpack(p *Packet) error {
-	if len(p.Payload) < 4 {
+	if len(p.Payload) < 3 {
 		return fmt.Errorf("payload too small")
 	}
 	self.Command = uint16(binary.LittleEndian.Uint16(p.Payload[0:]))
 	self.Result = uint8(p.Payload[2])
-	self.Progress = uint8(p.Payload[3])
 	return nil
 }
 
@@ -3529,8 +3462,8 @@ type AttitudeTarget struct {
 	TimeBootMs    uint32     // Timestamp in milliseconds since system boot
 	Q             [4]float32 // Attitude quaternion (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
 	BodyRollRate  float32    // Body roll rate in radians per second
-	BodyPitchRate float32    // Body pitch rate in radians per second
-	BodyYawRate   float32    // Body yaw rate in radians per second
+	BodyPitchRate float32    // Body roll rate in radians per second
+	BodyYawRate   float32    // Body roll rate in radians per second
 	Thrust        float32    // Collective thrust, normalized to 0 .. 1 (-1 .. 1 for vehicles capable of reverse trust)
 	TypeMask      uint8      // Mappings: If any of these bits are set, the corresponding input should be ignored: bit 1: body roll rate, bit 2: body pitch rate, bit 3: body yaw rate. bit 4-bit 7: reserved, bit 8: attitude
 }
@@ -4165,8 +4098,6 @@ type OpticalFlow struct {
 	FlowCompMX     float32 // Flow in meters in x-sensor direction, angular-speed compensated
 	FlowCompMY     float32 // Flow in meters in y-sensor direction, angular-speed compensated
 	GroundDistance float32 // Ground distance in meters. Positive value: distance known. Negative value: Unknown distance
-	FlowRateX      float32 // Flow rate in radians/second about X axis
-	FlowRateY      float32 // Flow rate in radians/second about Y axis
 	FlowX          int16   // Flow in pixels * 10 in x-sensor direction (dezi-pixels)
 	FlowY          int16   // Flow in pixels * 10 in y-sensor direction (dezi-pixels)
 	SensorId       uint8   // Sensor ID
@@ -4182,17 +4113,15 @@ func (self *OpticalFlow) MsgName() string {
 }
 
 func (self *OpticalFlow) Pack(p *Packet) error {
-	payload := make([]byte, 34)
+	payload := make([]byte, 26)
 	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUsec))
 	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.FlowCompMX))
 	binary.LittleEndian.PutUint32(payload[12:], math.Float32bits(self.FlowCompMY))
 	binary.LittleEndian.PutUint32(payload[16:], math.Float32bits(self.GroundDistance))
-	binary.LittleEndian.PutUint32(payload[20:], math.Float32bits(self.FlowRateX))
-	binary.LittleEndian.PutUint32(payload[24:], math.Float32bits(self.FlowRateY))
-	binary.LittleEndian.PutUint16(payload[28:], uint16(self.FlowX))
-	binary.LittleEndian.PutUint16(payload[30:], uint16(self.FlowY))
-	payload[32] = byte(self.SensorId)
-	payload[33] = byte(self.Quality)
+	binary.LittleEndian.PutUint16(payload[20:], uint16(self.FlowX))
+	binary.LittleEndian.PutUint16(payload[22:], uint16(self.FlowY))
+	payload[24] = byte(self.SensorId)
+	payload[25] = byte(self.Quality)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -4200,19 +4129,17 @@ func (self *OpticalFlow) Pack(p *Packet) error {
 }
 
 func (self *OpticalFlow) Unpack(p *Packet) error {
-	if len(p.Payload) < 34 {
+	if len(p.Payload) < 26 {
 		return fmt.Errorf("payload too small")
 	}
 	self.TimeUsec = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
 	self.FlowCompMX = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8:]))
 	self.FlowCompMY = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[12:]))
 	self.GroundDistance = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[16:]))
-	self.FlowRateX = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[20:]))
-	self.FlowRateY = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[24:]))
-	self.FlowX = int16(binary.LittleEndian.Uint16(p.Payload[28:]))
-	self.FlowY = int16(binary.LittleEndian.Uint16(p.Payload[30:]))
-	self.SensorId = uint8(p.Payload[32])
-	self.Quality = uint8(p.Payload[33])
+	self.FlowX = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
+	self.FlowY = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
+	self.SensorId = uint8(p.Payload[24])
+	self.Quality = uint8(p.Payload[25])
 	return nil
 }
 
@@ -4858,7 +4785,7 @@ type HilGps struct {
 	Alt               int32  // Altitude (AMSL, not WGS84), in meters * 1000 (positive for up)
 	Eph               uint16 // GPS HDOP horizontal dilution of position in cm (m*100). If unknown, set to: 65535
 	Epv               uint16 // GPS VDOP vertical dilution of position in cm (m*100). If unknown, set to: 65535
-	Vel               uint16 // GPS ground speed in cm/s. If unknown, set to: 65535
+	Vel               uint16 // GPS ground speed (m/s * 100). If unknown, set to: 65535
 	Vn                int16  // GPS velocity in cm/s in NORTH direction in earth-fixed NED frame
 	Ve                int16  // GPS velocity in cm/s in EAST direction in earth-fixed NED frame
 	Vd                int16  // GPS velocity in cm/s in DOWN direction in earth-fixed NED frame
@@ -4989,11 +4916,11 @@ type HilStateQuaternion struct {
 	Lat                int32      // Latitude, expressed as * 1E7
 	Lon                int32      // Longitude, expressed as * 1E7
 	Alt                int32      // Altitude in meters, expressed as * 1000 (millimeters)
-	Vx                 int16      // Ground X Speed (Latitude), expressed as cm/s
-	Vy                 int16      // Ground Y Speed (Longitude), expressed as cm/s
-	Vz                 int16      // Ground Z Speed (Altitude), expressed as cm/s
-	IndAirspeed        uint16     // Indicated airspeed, expressed as cm/s
-	TrueAirspeed       uint16     // True airspeed, expressed as cm/s
+	Vx                 int16      // Ground X Speed (Latitude), expressed as m/s * 100
+	Vy                 int16      // Ground Y Speed (Longitude), expressed as m/s * 100
+	Vz                 int16      // Ground Z Speed (Altitude), expressed as m/s * 100
+	IndAirspeed        uint16     // Indicated airspeed, expressed as m/s * 100
+	TrueAirspeed       uint16     // True airspeed, expressed as m/s * 100
 	Xacc               int16      // X acceleration (mg)
 	Yacc               int16      // Y acceleration (mg)
 	Zacc               int16      // Z acceleration (mg)
@@ -6486,7 +6413,7 @@ func (self *ControlSystemState) Unpack(p *Packet) error {
 // Battery information
 type BatteryStatus struct {
 	CurrentConsumed  int32      // Consumed charge, in milliampere hours (1 = 1 mAh), -1: autopilot does not provide mAh consumption estimate
-	EnergyConsumed   int32      // Consumed energy, in HectoJoules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate
+	EnergyConsumed   int32      // Consumed energy, in 100*Joules (intergrated U*I*dt)  (1 = 100 Joule), -1: autopilot does not provide energy consumption estimate
 	Temperature      int16      // Temperature of the battery in centi-degrees celsius. INT16_MAX for unknown temperature.
 	Voltages         [10]uint16 // Battery voltage of cells, in millivolts (1 = 1 millivolt). Cells above the valid cell count for this battery should have the UINT16_MAX value.
 	CurrentBattery   int16      // Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current
@@ -6844,9 +6771,9 @@ func (self *GpsInput) Unpack(p *Packet) error {
 	return nil
 }
 
-// RTCM message for injecting into the onboard GPS (used for DGPS)
+// WORK IN PROGRESS! RTCM message for injecting into the onboard GPS (used for DGPS)
 type GpsRtcmData struct {
-	Flags uint8      // LSB: 1 means message is fragmented, next 2 bits are the fragment ID, the remaining 5 bits are used for the sequence ID. Messages are only to be flushed to the GPS when the entire message has been reconstructed on the autopilot. The fragment ID specifies which order the fragments should be assembled into a buffer, while the sequence ID is used to detect a mismatch between different buffers. The buffer is considered fully reconstructed when either all 4 fragments are present, or all the fragments before the first fragment with a non full payload is received. This management is used to ensure that normal GPS operation doesn't corrupt RTCM data, and to recover from a unreliable transport delivery order.
+	Flags uint8      // LSB: 1 means message is fragmented
 	Len   uint8      // data length
 	Data  [180]uint8 // RTCM message (may be fragmented)
 }
@@ -6882,13 +6809,17 @@ func (self *GpsRtcmData) Unpack(p *Packet) error {
 
 // Message appropriate for high latency connections like Iridium
 type HighLatency struct {
+	TimeUsec         uint64 // Timestamp (microseconds since UNIX epoch)
 	CustomMode       uint32 // A bitfield for use for autopilot-specific flags.
 	Latitude         int32  // Latitude, expressed as degrees * 1E7
 	Longitude        int32  // Longitude, expressed as degrees * 1E7
 	Roll             int16  // roll (centidegrees)
 	Pitch            int16  // pitch (centidegrees)
 	Heading          uint16 // heading (centidegrees)
+	RollSp           int16  // roll setpoint (centidegrees)
+	PitchSp          int16  // pitch setpoint (centidegrees)
 	HeadingSp        int16  // heading setpoint (centidegrees)
+	AltitudeHome     int16  // Altitude above the home position (meters)
 	AltitudeAmsl     int16  // Altitude above mean sea level (meters)
 	AltitudeSp       int16  // Altitude setpoint relative to the home position (meters)
 	WpDistance       uint16 // distance to target (meters)
@@ -6917,31 +6848,35 @@ func (self *HighLatency) MsgName() string {
 }
 
 func (self *HighLatency) Pack(p *Packet) error {
-	payload := make([]byte, 40)
-	binary.LittleEndian.PutUint32(payload[0:], uint32(self.CustomMode))
-	binary.LittleEndian.PutUint32(payload[4:], uint32(self.Latitude))
-	binary.LittleEndian.PutUint32(payload[8:], uint32(self.Longitude))
-	binary.LittleEndian.PutUint16(payload[12:], uint16(self.Roll))
-	binary.LittleEndian.PutUint16(payload[14:], uint16(self.Pitch))
-	binary.LittleEndian.PutUint16(payload[16:], uint16(self.Heading))
-	binary.LittleEndian.PutUint16(payload[18:], uint16(self.HeadingSp))
-	binary.LittleEndian.PutUint16(payload[20:], uint16(self.AltitudeAmsl))
-	binary.LittleEndian.PutUint16(payload[22:], uint16(self.AltitudeSp))
-	binary.LittleEndian.PutUint16(payload[24:], uint16(self.WpDistance))
-	payload[26] = byte(self.BaseMode)
-	payload[27] = byte(self.LandedState)
-	payload[28] = byte(self.Throttle)
-	payload[29] = byte(self.Airspeed)
-	payload[30] = byte(self.AirspeedSp)
-	payload[31] = byte(self.Groundspeed)
-	payload[32] = byte(self.ClimbRate)
-	payload[33] = byte(self.GpsNsat)
-	payload[34] = byte(self.GpsFixType)
-	payload[35] = byte(self.BatteryRemaining)
-	payload[36] = byte(self.Temperature)
-	payload[37] = byte(self.TemperatureAir)
-	payload[38] = byte(self.Failsafe)
-	payload[39] = byte(self.WpNum)
+	payload := make([]byte, 54)
+	binary.LittleEndian.PutUint64(payload[0:], uint64(self.TimeUsec))
+	binary.LittleEndian.PutUint32(payload[8:], uint32(self.CustomMode))
+	binary.LittleEndian.PutUint32(payload[12:], uint32(self.Latitude))
+	binary.LittleEndian.PutUint32(payload[16:], uint32(self.Longitude))
+	binary.LittleEndian.PutUint16(payload[20:], uint16(self.Roll))
+	binary.LittleEndian.PutUint16(payload[22:], uint16(self.Pitch))
+	binary.LittleEndian.PutUint16(payload[24:], uint16(self.Heading))
+	binary.LittleEndian.PutUint16(payload[26:], uint16(self.RollSp))
+	binary.LittleEndian.PutUint16(payload[28:], uint16(self.PitchSp))
+	binary.LittleEndian.PutUint16(payload[30:], uint16(self.HeadingSp))
+	binary.LittleEndian.PutUint16(payload[32:], uint16(self.AltitudeHome))
+	binary.LittleEndian.PutUint16(payload[34:], uint16(self.AltitudeAmsl))
+	binary.LittleEndian.PutUint16(payload[36:], uint16(self.AltitudeSp))
+	binary.LittleEndian.PutUint16(payload[38:], uint16(self.WpDistance))
+	payload[40] = byte(self.BaseMode)
+	payload[41] = byte(self.LandedState)
+	payload[42] = byte(self.Throttle)
+	payload[43] = byte(self.Airspeed)
+	payload[44] = byte(self.AirspeedSp)
+	payload[45] = byte(self.Groundspeed)
+	payload[46] = byte(self.ClimbRate)
+	payload[47] = byte(self.GpsNsat)
+	payload[48] = byte(self.GpsFixType)
+	payload[49] = byte(self.BatteryRemaining)
+	payload[50] = byte(self.Temperature)
+	payload[51] = byte(self.TemperatureAir)
+	payload[52] = byte(self.Failsafe)
+	payload[53] = byte(self.WpNum)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -6949,33 +6884,37 @@ func (self *HighLatency) Pack(p *Packet) error {
 }
 
 func (self *HighLatency) Unpack(p *Packet) error {
-	if len(p.Payload) < 40 {
+	if len(p.Payload) < 54 {
 		return fmt.Errorf("payload too small")
 	}
-	self.CustomMode = uint32(binary.LittleEndian.Uint32(p.Payload[0:]))
-	self.Latitude = int32(binary.LittleEndian.Uint32(p.Payload[4:]))
-	self.Longitude = int32(binary.LittleEndian.Uint32(p.Payload[8:]))
-	self.Roll = int16(binary.LittleEndian.Uint16(p.Payload[12:]))
-	self.Pitch = int16(binary.LittleEndian.Uint16(p.Payload[14:]))
-	self.Heading = uint16(binary.LittleEndian.Uint16(p.Payload[16:]))
-	self.HeadingSp = int16(binary.LittleEndian.Uint16(p.Payload[18:]))
-	self.AltitudeAmsl = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
-	self.AltitudeSp = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
-	self.WpDistance = uint16(binary.LittleEndian.Uint16(p.Payload[24:]))
-	self.BaseMode = uint8(p.Payload[26])
-	self.LandedState = uint8(p.Payload[27])
-	self.Throttle = int8(p.Payload[28])
-	self.Airspeed = uint8(p.Payload[29])
-	self.AirspeedSp = uint8(p.Payload[30])
-	self.Groundspeed = uint8(p.Payload[31])
-	self.ClimbRate = int8(p.Payload[32])
-	self.GpsNsat = uint8(p.Payload[33])
-	self.GpsFixType = uint8(p.Payload[34])
-	self.BatteryRemaining = uint8(p.Payload[35])
-	self.Temperature = int8(p.Payload[36])
-	self.TemperatureAir = int8(p.Payload[37])
-	self.Failsafe = uint8(p.Payload[38])
-	self.WpNum = uint8(p.Payload[39])
+	self.TimeUsec = uint64(binary.LittleEndian.Uint64(p.Payload[0:]))
+	self.CustomMode = uint32(binary.LittleEndian.Uint32(p.Payload[8:]))
+	self.Latitude = int32(binary.LittleEndian.Uint32(p.Payload[12:]))
+	self.Longitude = int32(binary.LittleEndian.Uint32(p.Payload[16:]))
+	self.Roll = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
+	self.Pitch = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
+	self.Heading = uint16(binary.LittleEndian.Uint16(p.Payload[24:]))
+	self.RollSp = int16(binary.LittleEndian.Uint16(p.Payload[26:]))
+	self.PitchSp = int16(binary.LittleEndian.Uint16(p.Payload[28:]))
+	self.HeadingSp = int16(binary.LittleEndian.Uint16(p.Payload[30:]))
+	self.AltitudeHome = int16(binary.LittleEndian.Uint16(p.Payload[32:]))
+	self.AltitudeAmsl = int16(binary.LittleEndian.Uint16(p.Payload[34:]))
+	self.AltitudeSp = int16(binary.LittleEndian.Uint16(p.Payload[36:]))
+	self.WpDistance = uint16(binary.LittleEndian.Uint16(p.Payload[38:]))
+	self.BaseMode = uint8(p.Payload[40])
+	self.LandedState = uint8(p.Payload[41])
+	self.Throttle = int8(p.Payload[42])
+	self.Airspeed = uint8(p.Payload[43])
+	self.AirspeedSp = uint8(p.Payload[44])
+	self.Groundspeed = uint8(p.Payload[45])
+	self.ClimbRate = int8(p.Payload[46])
+	self.GpsNsat = uint8(p.Payload[47])
+	self.GpsFixType = uint8(p.Payload[48])
+	self.BatteryRemaining = uint8(p.Payload[49])
+	self.Temperature = int8(p.Payload[50])
+	self.TemperatureAir = int8(p.Payload[51])
+	self.Failsafe = uint8(p.Payload[52])
+	self.WpNum = uint8(p.Payload[53])
 	return nil
 }
 
@@ -7154,7 +7093,7 @@ func (self *SetHomePosition) Unpack(p *Packet) error {
 
 // This interface replaces DATA_STREAM
 type MessageInterval struct {
-	IntervalUs int32  // The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, &gt; 0 indicates the interval at which it is sent.
+	IntervalUs int32  // The interval between two messages, in microseconds. A value of -1 indicates this stream is disabled, 0 indicates it is not available, > 0 indicates the interval at which it is sent.
 	MessageId  uint16 // The ID of the requested MAVLink message. v1.0 is limited to 254 messages.
 }
 
@@ -7769,37 +7708,37 @@ var DialectCommon *Dialect = &Dialect{
 		MSG_ID_RC_CHANNELS_SCALED:                      237,
 		MSG_ID_RC_CHANNELS_RAW:                         244,
 		MSG_ID_SERVO_OUTPUT_RAW:                        175,
-		MSG_ID_MISSION_REQUEST_PARTIAL_LIST:            4,
-		MSG_ID_MISSION_WRITE_PARTIAL_LIST:              168,
-		MSG_ID_MISSION_ITEM:                            95,
-		MSG_ID_MISSION_REQUEST:                         177,
+		MSG_ID_MISSION_REQUEST_PARTIAL_LIST:            212,
+		MSG_ID_MISSION_WRITE_PARTIAL_LIST:              9,
+		MSG_ID_MISSION_ITEM:                            254,
+		MSG_ID_MISSION_REQUEST:                         230,
 		MSG_ID_MISSION_SET_CURRENT:                     28,
 		MSG_ID_MISSION_CURRENT:                         28,
-		MSG_ID_MISSION_REQUEST_LIST:                    148,
-		MSG_ID_MISSION_COUNT:                           52,
-		MSG_ID_MISSION_CLEAR_ALL:                       25,
+		MSG_ID_MISSION_REQUEST_LIST:                    132,
+		MSG_ID_MISSION_COUNT:                           221,
+		MSG_ID_MISSION_CLEAR_ALL:                       232,
 		MSG_ID_MISSION_ITEM_REACHED:                    11,
-		MSG_ID_MISSION_ACK:                             146,
+		MSG_ID_MISSION_ACK:                             153,
 		MSG_ID_SET_GPS_GLOBAL_ORIGIN:                   41,
 		MSG_ID_GPS_GLOBAL_ORIGIN:                       39,
 		MSG_ID_PARAM_MAP_RC:                            78,
-		MSG_ID_MISSION_REQUEST_INT:                     129,
+		MSG_ID_MISSION_REQUEST_INT:                     196,
 		MSG_ID_SAFETY_SET_ALLOWED_AREA:                 15,
 		MSG_ID_SAFETY_ALLOWED_AREA:                     3,
-		MSG_ID_ATTITUDE_QUATERNION_COV:                 167,
+		MSG_ID_ATTITUDE_QUATERNION_COV:                 153,
 		MSG_ID_NAV_CONTROLLER_OUTPUT:                   183,
-		MSG_ID_GLOBAL_POSITION_INT_COV:                 119,
-		MSG_ID_LOCAL_POSITION_NED_COV:                  191,
+		MSG_ID_GLOBAL_POSITION_INT_COV:                 51,
+		MSG_ID_LOCAL_POSITION_NED_COV:                  59,
 		MSG_ID_RC_CHANNELS:                             118,
 		MSG_ID_REQUEST_DATA_STREAM:                     148,
 		MSG_ID_DATA_STREAM:                             21,
 		MSG_ID_MANUAL_CONTROL:                          243,
 		MSG_ID_RC_CHANNELS_OVERRIDE:                    124,
-		MSG_ID_MISSION_ITEM_INT:                        209,
+		MSG_ID_MISSION_ITEM_INT:                        38,
 		MSG_ID_VFR_HUD:                                 20,
 		MSG_ID_COMMAND_INT:                             158,
 		MSG_ID_COMMAND_LONG:                            152,
-		MSG_ID_COMMAND_ACK:                             189,
+		MSG_ID_COMMAND_ACK:                             143,
 		MSG_ID_MANUAL_SETPOINT:                         106,
 		MSG_ID_SET_ATTITUDE_TARGET:                     49,
 		MSG_ID_ATTITUDE_TARGET:                         22,
@@ -7812,7 +7751,7 @@ var DialectCommon *Dialect = &Dialect{
 		MSG_ID_HIL_CONTROLS:                            63,
 		MSG_ID_HIL_RC_INPUTS_RAW:                       54,
 		MSG_ID_HIL_ACTUATOR_CONTROLS:                   47,
-		MSG_ID_OPTICAL_FLOW:                            145,
+		MSG_ID_OPTICAL_FLOW:                            175,
 		MSG_ID_GLOBAL_VISION_POSITION_ESTIMATE:         102,
 		MSG_ID_VISION_POSITION_ESTIMATE:                158,
 		MSG_ID_VISION_SPEED_ESTIMATE:                   208,
@@ -7865,7 +7804,7 @@ var DialectCommon *Dialect = &Dialect{
 		MSG_ID_WIND_COV:                                105,
 		MSG_ID_GPS_INPUT:                               151,
 		MSG_ID_GPS_RTCM_DATA:                           35,
-		MSG_ID_HIGH_LATENCY:                            150,
+		MSG_ID_HIGH_LATENCY:                            179,
 		MSG_ID_VIBRATION:                               90,
 		MSG_ID_HOME_POSITION:                           104,
 		MSG_ID_SET_HOME_POSITION:                       85,

--- a/mavlink/matrixpilot.go
+++ b/mavlink/matrixpilot.go
@@ -374,7 +374,6 @@ type SerialUdbExtraF2A struct {
 	SueCog            uint16 // Serial UDB Extra GPS Course Over Ground
 	SueSog            int16  // Serial UDB Extra Speed Over Ground
 	SueCpuLoad        uint16 // Serial UDB Extra CPU Load
-	SueVoltageMilis   int16  // Serial UDB Extra Voltage in MilliVolts
 	SueAirSpeed3dimu  uint16 // Serial UDB Extra 3D IMU Air Speed
 	SueEstimatedWind0 int16  // Serial UDB Extra Estimated Wind 0
 	SueEstimatedWind1 int16  // Serial UDB Extra Estimated Wind 1
@@ -396,7 +395,7 @@ func (self *SerialUdbExtraF2A) MsgName() string {
 }
 
 func (self *SerialUdbExtraF2A) Pack(p *Packet) error {
-	payload := make([]byte, 63)
+	payload := make([]byte, 61)
 	binary.LittleEndian.PutUint32(payload[0:], uint32(self.SueTime))
 	binary.LittleEndian.PutUint32(payload[4:], uint32(self.SueLatitude))
 	binary.LittleEndian.PutUint32(payload[8:], uint32(self.SueLongitude))
@@ -414,17 +413,16 @@ func (self *SerialUdbExtraF2A) Pack(p *Packet) error {
 	binary.LittleEndian.PutUint16(payload[36:], uint16(self.SueCog))
 	binary.LittleEndian.PutUint16(payload[38:], uint16(self.SueSog))
 	binary.LittleEndian.PutUint16(payload[40:], uint16(self.SueCpuLoad))
-	binary.LittleEndian.PutUint16(payload[42:], uint16(self.SueVoltageMilis))
-	binary.LittleEndian.PutUint16(payload[44:], uint16(self.SueAirSpeed3dimu))
-	binary.LittleEndian.PutUint16(payload[46:], uint16(self.SueEstimatedWind0))
-	binary.LittleEndian.PutUint16(payload[48:], uint16(self.SueEstimatedWind1))
-	binary.LittleEndian.PutUint16(payload[50:], uint16(self.SueEstimatedWind2))
-	binary.LittleEndian.PutUint16(payload[52:], uint16(self.SueMagfieldearth0))
-	binary.LittleEndian.PutUint16(payload[54:], uint16(self.SueMagfieldearth1))
-	binary.LittleEndian.PutUint16(payload[56:], uint16(self.SueMagfieldearth2))
-	binary.LittleEndian.PutUint16(payload[58:], uint16(self.SueSvs))
-	binary.LittleEndian.PutUint16(payload[60:], uint16(self.SueHdop))
-	payload[62] = byte(self.SueStatus)
+	binary.LittleEndian.PutUint16(payload[42:], uint16(self.SueAirSpeed3dimu))
+	binary.LittleEndian.PutUint16(payload[44:], uint16(self.SueEstimatedWind0))
+	binary.LittleEndian.PutUint16(payload[46:], uint16(self.SueEstimatedWind1))
+	binary.LittleEndian.PutUint16(payload[48:], uint16(self.SueEstimatedWind2))
+	binary.LittleEndian.PutUint16(payload[50:], uint16(self.SueMagfieldearth0))
+	binary.LittleEndian.PutUint16(payload[52:], uint16(self.SueMagfieldearth1))
+	binary.LittleEndian.PutUint16(payload[54:], uint16(self.SueMagfieldearth2))
+	binary.LittleEndian.PutUint16(payload[56:], uint16(self.SueSvs))
+	binary.LittleEndian.PutUint16(payload[58:], uint16(self.SueHdop))
+	payload[60] = byte(self.SueStatus)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -432,7 +430,7 @@ func (self *SerialUdbExtraF2A) Pack(p *Packet) error {
 }
 
 func (self *SerialUdbExtraF2A) Unpack(p *Packet) error {
-	if len(p.Payload) < 63 {
+	if len(p.Payload) < 61 {
 		return fmt.Errorf("payload too small")
 	}
 	self.SueTime = uint32(binary.LittleEndian.Uint32(p.Payload[0:]))
@@ -452,55 +450,71 @@ func (self *SerialUdbExtraF2A) Unpack(p *Packet) error {
 	self.SueCog = uint16(binary.LittleEndian.Uint16(p.Payload[36:]))
 	self.SueSog = int16(binary.LittleEndian.Uint16(p.Payload[38:]))
 	self.SueCpuLoad = uint16(binary.LittleEndian.Uint16(p.Payload[40:]))
-	self.SueVoltageMilis = int16(binary.LittleEndian.Uint16(p.Payload[42:]))
-	self.SueAirSpeed3dimu = uint16(binary.LittleEndian.Uint16(p.Payload[44:]))
-	self.SueEstimatedWind0 = int16(binary.LittleEndian.Uint16(p.Payload[46:]))
-	self.SueEstimatedWind1 = int16(binary.LittleEndian.Uint16(p.Payload[48:]))
-	self.SueEstimatedWind2 = int16(binary.LittleEndian.Uint16(p.Payload[50:]))
-	self.SueMagfieldearth0 = int16(binary.LittleEndian.Uint16(p.Payload[52:]))
-	self.SueMagfieldearth1 = int16(binary.LittleEndian.Uint16(p.Payload[54:]))
-	self.SueMagfieldearth2 = int16(binary.LittleEndian.Uint16(p.Payload[56:]))
-	self.SueSvs = int16(binary.LittleEndian.Uint16(p.Payload[58:]))
-	self.SueHdop = int16(binary.LittleEndian.Uint16(p.Payload[60:]))
-	self.SueStatus = uint8(p.Payload[62])
+	self.SueAirSpeed3dimu = uint16(binary.LittleEndian.Uint16(p.Payload[42:]))
+	self.SueEstimatedWind0 = int16(binary.LittleEndian.Uint16(p.Payload[44:]))
+	self.SueEstimatedWind1 = int16(binary.LittleEndian.Uint16(p.Payload[46:]))
+	self.SueEstimatedWind2 = int16(binary.LittleEndian.Uint16(p.Payload[48:]))
+	self.SueMagfieldearth0 = int16(binary.LittleEndian.Uint16(p.Payload[50:]))
+	self.SueMagfieldearth1 = int16(binary.LittleEndian.Uint16(p.Payload[52:]))
+	self.SueMagfieldearth2 = int16(binary.LittleEndian.Uint16(p.Payload[54:]))
+	self.SueSvs = int16(binary.LittleEndian.Uint16(p.Payload[56:]))
+	self.SueHdop = int16(binary.LittleEndian.Uint16(p.Payload[58:]))
+	self.SueStatus = uint8(p.Payload[60])
 	return nil
 }
 
 // Backwards compatible version of SERIAL_UDB_EXTRA - F2: Part B
 type SerialUdbExtraF2B struct {
-	SueTime            uint32 // Serial UDB Extra Time
-	SueFlags           uint32 // Serial UDB Extra Status Flags
-	SuePwmInput1       int16  // Serial UDB Extra PWM Input Channel 1
-	SuePwmInput2       int16  // Serial UDB Extra PWM Input Channel 2
-	SuePwmInput3       int16  // Serial UDB Extra PWM Input Channel 3
-	SuePwmInput4       int16  // Serial UDB Extra PWM Input Channel 4
-	SuePwmInput5       int16  // Serial UDB Extra PWM Input Channel 5
-	SuePwmInput6       int16  // Serial UDB Extra PWM Input Channel 6
-	SuePwmInput7       int16  // Serial UDB Extra PWM Input Channel 7
-	SuePwmInput8       int16  // Serial UDB Extra PWM Input Channel 8
-	SuePwmInput9       int16  // Serial UDB Extra PWM Input Channel 9
-	SuePwmInput10      int16  // Serial UDB Extra PWM Input Channel 10
-	SuePwmOutput1      int16  // Serial UDB Extra PWM Output Channel 1
-	SuePwmOutput2      int16  // Serial UDB Extra PWM Output Channel 2
-	SuePwmOutput3      int16  // Serial UDB Extra PWM Output Channel 3
-	SuePwmOutput4      int16  // Serial UDB Extra PWM Output Channel 4
-	SuePwmOutput5      int16  // Serial UDB Extra PWM Output Channel 5
-	SuePwmOutput6      int16  // Serial UDB Extra PWM Output Channel 6
-	SuePwmOutput7      int16  // Serial UDB Extra PWM Output Channel 7
-	SuePwmOutput8      int16  // Serial UDB Extra PWM Output Channel 8
-	SuePwmOutput9      int16  // Serial UDB Extra PWM Output Channel 9
-	SuePwmOutput10     int16  // Serial UDB Extra PWM Output Channel 10
-	SueImuLocationX    int16  // Serial UDB Extra IMU Location X
-	SueImuLocationY    int16  // Serial UDB Extra IMU Location Y
-	SueImuLocationZ    int16  // Serial UDB Extra IMU Location Z
-	SueOscFails        int16  // Serial UDB Extra Oscillator Failure Count
-	SueImuVelocityX    int16  // Serial UDB Extra IMU Velocity X
-	SueImuVelocityY    int16  // Serial UDB Extra IMU Velocity Y
-	SueImuVelocityZ    int16  // Serial UDB Extra IMU Velocity Z
-	SueWaypointGoalX   int16  // Serial UDB Extra Current Waypoint Goal X
-	SueWaypointGoalY   int16  // Serial UDB Extra Current Waypoint Goal Y
-	SueWaypointGoalZ   int16  // Serial UDB Extra Current Waypoint Goal Z
-	SueMemoryStackFree int16  // Serial UDB Extra Stack Memory Free
+	SueTime                uint32 // Serial UDB Extra Time
+	SueFlags               uint32 // Serial UDB Extra Status Flags
+	SueBaromPress          int32  // SUE barometer pressure
+	SueBaromAlt            int32  // SUE barometer altitude
+	SuePwmInput1           int16  // Serial UDB Extra PWM Input Channel 1
+	SuePwmInput2           int16  // Serial UDB Extra PWM Input Channel 2
+	SuePwmInput3           int16  // Serial UDB Extra PWM Input Channel 3
+	SuePwmInput4           int16  // Serial UDB Extra PWM Input Channel 4
+	SuePwmInput5           int16  // Serial UDB Extra PWM Input Channel 5
+	SuePwmInput6           int16  // Serial UDB Extra PWM Input Channel 6
+	SuePwmInput7           int16  // Serial UDB Extra PWM Input Channel 7
+	SuePwmInput8           int16  // Serial UDB Extra PWM Input Channel 8
+	SuePwmInput9           int16  // Serial UDB Extra PWM Input Channel 9
+	SuePwmInput10          int16  // Serial UDB Extra PWM Input Channel 10
+	SuePwmInput11          int16  // Serial UDB Extra PWM Input Channel 11
+	SuePwmInput12          int16  // Serial UDB Extra PWM Input Channel 12
+	SuePwmOutput1          int16  // Serial UDB Extra PWM Output Channel 1
+	SuePwmOutput2          int16  // Serial UDB Extra PWM Output Channel 2
+	SuePwmOutput3          int16  // Serial UDB Extra PWM Output Channel 3
+	SuePwmOutput4          int16  // Serial UDB Extra PWM Output Channel 4
+	SuePwmOutput5          int16  // Serial UDB Extra PWM Output Channel 5
+	SuePwmOutput6          int16  // Serial UDB Extra PWM Output Channel 6
+	SuePwmOutput7          int16  // Serial UDB Extra PWM Output Channel 7
+	SuePwmOutput8          int16  // Serial UDB Extra PWM Output Channel 8
+	SuePwmOutput9          int16  // Serial UDB Extra PWM Output Channel 9
+	SuePwmOutput10         int16  // Serial UDB Extra PWM Output Channel 10
+	SuePwmOutput11         int16  // Serial UDB Extra PWM Output Channel 11
+	SuePwmOutput12         int16  // Serial UDB Extra PWM Output Channel 12
+	SueImuLocationX        int16  // Serial UDB Extra IMU Location X
+	SueImuLocationY        int16  // Serial UDB Extra IMU Location Y
+	SueImuLocationZ        int16  // Serial UDB Extra IMU Location Z
+	SueLocationErrorEarthX int16  // Serial UDB Location Error Earth X
+	SueLocationErrorEarthY int16  // Serial UDB Location Error Earth Y
+	SueLocationErrorEarthZ int16  // Serial UDB Location Error Earth Z
+	SueOscFails            int16  // Serial UDB Extra Oscillator Failure Count
+	SueImuVelocityX        int16  // Serial UDB Extra IMU Velocity X
+	SueImuVelocityY        int16  // Serial UDB Extra IMU Velocity Y
+	SueImuVelocityZ        int16  // Serial UDB Extra IMU Velocity Z
+	SueWaypointGoalX       int16  // Serial UDB Extra Current Waypoint Goal X
+	SueWaypointGoalY       int16  // Serial UDB Extra Current Waypoint Goal Y
+	SueWaypointGoalZ       int16  // Serial UDB Extra Current Waypoint Goal Z
+	SueAeroX               int16  // Aeroforce in UDB X Axis
+	SueAeroY               int16  // Aeroforce in UDB Y Axis
+	SueAeroZ               int16  // Aeroforce in UDB Z axis
+	SueBaromTemp           int16  // SUE barometer temperature
+	SueBatVolt             int16  // SUE battery voltage
+	SueBatAmp              int16  // SUE battery current
+	SueBatAmpHours         int16  // SUE battery milli amp hours used
+	SueDesiredHeight       int16  // Sue autopilot desired height
+	SueMemoryStackFree     int16  // Serial UDB Extra Stack Memory Free
 }
 
 func (self *SerialUdbExtraF2B) MsgID() MessageID {
@@ -512,40 +526,57 @@ func (self *SerialUdbExtraF2B) MsgName() string {
 }
 
 func (self *SerialUdbExtraF2B) Pack(p *Packet) error {
-	payload := make([]byte, 70)
+	payload := make([]byte, 108)
 	binary.LittleEndian.PutUint32(payload[0:], uint32(self.SueTime))
 	binary.LittleEndian.PutUint32(payload[4:], uint32(self.SueFlags))
-	binary.LittleEndian.PutUint16(payload[8:], uint16(self.SuePwmInput1))
-	binary.LittleEndian.PutUint16(payload[10:], uint16(self.SuePwmInput2))
-	binary.LittleEndian.PutUint16(payload[12:], uint16(self.SuePwmInput3))
-	binary.LittleEndian.PutUint16(payload[14:], uint16(self.SuePwmInput4))
-	binary.LittleEndian.PutUint16(payload[16:], uint16(self.SuePwmInput5))
-	binary.LittleEndian.PutUint16(payload[18:], uint16(self.SuePwmInput6))
-	binary.LittleEndian.PutUint16(payload[20:], uint16(self.SuePwmInput7))
-	binary.LittleEndian.PutUint16(payload[22:], uint16(self.SuePwmInput8))
-	binary.LittleEndian.PutUint16(payload[24:], uint16(self.SuePwmInput9))
-	binary.LittleEndian.PutUint16(payload[26:], uint16(self.SuePwmInput10))
-	binary.LittleEndian.PutUint16(payload[28:], uint16(self.SuePwmOutput1))
-	binary.LittleEndian.PutUint16(payload[30:], uint16(self.SuePwmOutput2))
-	binary.LittleEndian.PutUint16(payload[32:], uint16(self.SuePwmOutput3))
-	binary.LittleEndian.PutUint16(payload[34:], uint16(self.SuePwmOutput4))
-	binary.LittleEndian.PutUint16(payload[36:], uint16(self.SuePwmOutput5))
-	binary.LittleEndian.PutUint16(payload[38:], uint16(self.SuePwmOutput6))
-	binary.LittleEndian.PutUint16(payload[40:], uint16(self.SuePwmOutput7))
-	binary.LittleEndian.PutUint16(payload[42:], uint16(self.SuePwmOutput8))
-	binary.LittleEndian.PutUint16(payload[44:], uint16(self.SuePwmOutput9))
-	binary.LittleEndian.PutUint16(payload[46:], uint16(self.SuePwmOutput10))
-	binary.LittleEndian.PutUint16(payload[48:], uint16(self.SueImuLocationX))
-	binary.LittleEndian.PutUint16(payload[50:], uint16(self.SueImuLocationY))
-	binary.LittleEndian.PutUint16(payload[52:], uint16(self.SueImuLocationZ))
-	binary.LittleEndian.PutUint16(payload[54:], uint16(self.SueOscFails))
-	binary.LittleEndian.PutUint16(payload[56:], uint16(self.SueImuVelocityX))
-	binary.LittleEndian.PutUint16(payload[58:], uint16(self.SueImuVelocityY))
-	binary.LittleEndian.PutUint16(payload[60:], uint16(self.SueImuVelocityZ))
-	binary.LittleEndian.PutUint16(payload[62:], uint16(self.SueWaypointGoalX))
-	binary.LittleEndian.PutUint16(payload[64:], uint16(self.SueWaypointGoalY))
-	binary.LittleEndian.PutUint16(payload[66:], uint16(self.SueWaypointGoalZ))
-	binary.LittleEndian.PutUint16(payload[68:], uint16(self.SueMemoryStackFree))
+	binary.LittleEndian.PutUint32(payload[8:], uint32(self.SueBaromPress))
+	binary.LittleEndian.PutUint32(payload[12:], uint32(self.SueBaromAlt))
+	binary.LittleEndian.PutUint16(payload[16:], uint16(self.SuePwmInput1))
+	binary.LittleEndian.PutUint16(payload[18:], uint16(self.SuePwmInput2))
+	binary.LittleEndian.PutUint16(payload[20:], uint16(self.SuePwmInput3))
+	binary.LittleEndian.PutUint16(payload[22:], uint16(self.SuePwmInput4))
+	binary.LittleEndian.PutUint16(payload[24:], uint16(self.SuePwmInput5))
+	binary.LittleEndian.PutUint16(payload[26:], uint16(self.SuePwmInput6))
+	binary.LittleEndian.PutUint16(payload[28:], uint16(self.SuePwmInput7))
+	binary.LittleEndian.PutUint16(payload[30:], uint16(self.SuePwmInput8))
+	binary.LittleEndian.PutUint16(payload[32:], uint16(self.SuePwmInput9))
+	binary.LittleEndian.PutUint16(payload[34:], uint16(self.SuePwmInput10))
+	binary.LittleEndian.PutUint16(payload[36:], uint16(self.SuePwmInput11))
+	binary.LittleEndian.PutUint16(payload[38:], uint16(self.SuePwmInput12))
+	binary.LittleEndian.PutUint16(payload[40:], uint16(self.SuePwmOutput1))
+	binary.LittleEndian.PutUint16(payload[42:], uint16(self.SuePwmOutput2))
+	binary.LittleEndian.PutUint16(payload[44:], uint16(self.SuePwmOutput3))
+	binary.LittleEndian.PutUint16(payload[46:], uint16(self.SuePwmOutput4))
+	binary.LittleEndian.PutUint16(payload[48:], uint16(self.SuePwmOutput5))
+	binary.LittleEndian.PutUint16(payload[50:], uint16(self.SuePwmOutput6))
+	binary.LittleEndian.PutUint16(payload[52:], uint16(self.SuePwmOutput7))
+	binary.LittleEndian.PutUint16(payload[54:], uint16(self.SuePwmOutput8))
+	binary.LittleEndian.PutUint16(payload[56:], uint16(self.SuePwmOutput9))
+	binary.LittleEndian.PutUint16(payload[58:], uint16(self.SuePwmOutput10))
+	binary.LittleEndian.PutUint16(payload[60:], uint16(self.SuePwmOutput11))
+	binary.LittleEndian.PutUint16(payload[62:], uint16(self.SuePwmOutput12))
+	binary.LittleEndian.PutUint16(payload[64:], uint16(self.SueImuLocationX))
+	binary.LittleEndian.PutUint16(payload[66:], uint16(self.SueImuLocationY))
+	binary.LittleEndian.PutUint16(payload[68:], uint16(self.SueImuLocationZ))
+	binary.LittleEndian.PutUint16(payload[70:], uint16(self.SueLocationErrorEarthX))
+	binary.LittleEndian.PutUint16(payload[72:], uint16(self.SueLocationErrorEarthY))
+	binary.LittleEndian.PutUint16(payload[74:], uint16(self.SueLocationErrorEarthZ))
+	binary.LittleEndian.PutUint16(payload[76:], uint16(self.SueOscFails))
+	binary.LittleEndian.PutUint16(payload[78:], uint16(self.SueImuVelocityX))
+	binary.LittleEndian.PutUint16(payload[80:], uint16(self.SueImuVelocityY))
+	binary.LittleEndian.PutUint16(payload[82:], uint16(self.SueImuVelocityZ))
+	binary.LittleEndian.PutUint16(payload[84:], uint16(self.SueWaypointGoalX))
+	binary.LittleEndian.PutUint16(payload[86:], uint16(self.SueWaypointGoalY))
+	binary.LittleEndian.PutUint16(payload[88:], uint16(self.SueWaypointGoalZ))
+	binary.LittleEndian.PutUint16(payload[90:], uint16(self.SueAeroX))
+	binary.LittleEndian.PutUint16(payload[92:], uint16(self.SueAeroY))
+	binary.LittleEndian.PutUint16(payload[94:], uint16(self.SueAeroZ))
+	binary.LittleEndian.PutUint16(payload[96:], uint16(self.SueBaromTemp))
+	binary.LittleEndian.PutUint16(payload[98:], uint16(self.SueBatVolt))
+	binary.LittleEndian.PutUint16(payload[100:], uint16(self.SueBatAmp))
+	binary.LittleEndian.PutUint16(payload[102:], uint16(self.SueBatAmpHours))
+	binary.LittleEndian.PutUint16(payload[104:], uint16(self.SueDesiredHeight))
+	binary.LittleEndian.PutUint16(payload[106:], uint16(self.SueMemoryStackFree))
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -553,42 +584,59 @@ func (self *SerialUdbExtraF2B) Pack(p *Packet) error {
 }
 
 func (self *SerialUdbExtraF2B) Unpack(p *Packet) error {
-	if len(p.Payload) < 70 {
+	if len(p.Payload) < 108 {
 		return fmt.Errorf("payload too small")
 	}
 	self.SueTime = uint32(binary.LittleEndian.Uint32(p.Payload[0:]))
 	self.SueFlags = uint32(binary.LittleEndian.Uint32(p.Payload[4:]))
-	self.SuePwmInput1 = int16(binary.LittleEndian.Uint16(p.Payload[8:]))
-	self.SuePwmInput2 = int16(binary.LittleEndian.Uint16(p.Payload[10:]))
-	self.SuePwmInput3 = int16(binary.LittleEndian.Uint16(p.Payload[12:]))
-	self.SuePwmInput4 = int16(binary.LittleEndian.Uint16(p.Payload[14:]))
-	self.SuePwmInput5 = int16(binary.LittleEndian.Uint16(p.Payload[16:]))
-	self.SuePwmInput6 = int16(binary.LittleEndian.Uint16(p.Payload[18:]))
-	self.SuePwmInput7 = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
-	self.SuePwmInput8 = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
-	self.SuePwmInput9 = int16(binary.LittleEndian.Uint16(p.Payload[24:]))
-	self.SuePwmInput10 = int16(binary.LittleEndian.Uint16(p.Payload[26:]))
-	self.SuePwmOutput1 = int16(binary.LittleEndian.Uint16(p.Payload[28:]))
-	self.SuePwmOutput2 = int16(binary.LittleEndian.Uint16(p.Payload[30:]))
-	self.SuePwmOutput3 = int16(binary.LittleEndian.Uint16(p.Payload[32:]))
-	self.SuePwmOutput4 = int16(binary.LittleEndian.Uint16(p.Payload[34:]))
-	self.SuePwmOutput5 = int16(binary.LittleEndian.Uint16(p.Payload[36:]))
-	self.SuePwmOutput6 = int16(binary.LittleEndian.Uint16(p.Payload[38:]))
-	self.SuePwmOutput7 = int16(binary.LittleEndian.Uint16(p.Payload[40:]))
-	self.SuePwmOutput8 = int16(binary.LittleEndian.Uint16(p.Payload[42:]))
-	self.SuePwmOutput9 = int16(binary.LittleEndian.Uint16(p.Payload[44:]))
-	self.SuePwmOutput10 = int16(binary.LittleEndian.Uint16(p.Payload[46:]))
-	self.SueImuLocationX = int16(binary.LittleEndian.Uint16(p.Payload[48:]))
-	self.SueImuLocationY = int16(binary.LittleEndian.Uint16(p.Payload[50:]))
-	self.SueImuLocationZ = int16(binary.LittleEndian.Uint16(p.Payload[52:]))
-	self.SueOscFails = int16(binary.LittleEndian.Uint16(p.Payload[54:]))
-	self.SueImuVelocityX = int16(binary.LittleEndian.Uint16(p.Payload[56:]))
-	self.SueImuVelocityY = int16(binary.LittleEndian.Uint16(p.Payload[58:]))
-	self.SueImuVelocityZ = int16(binary.LittleEndian.Uint16(p.Payload[60:]))
-	self.SueWaypointGoalX = int16(binary.LittleEndian.Uint16(p.Payload[62:]))
-	self.SueWaypointGoalY = int16(binary.LittleEndian.Uint16(p.Payload[64:]))
-	self.SueWaypointGoalZ = int16(binary.LittleEndian.Uint16(p.Payload[66:]))
-	self.SueMemoryStackFree = int16(binary.LittleEndian.Uint16(p.Payload[68:]))
+	self.SueBaromPress = int32(binary.LittleEndian.Uint32(p.Payload[8:]))
+	self.SueBaromAlt = int32(binary.LittleEndian.Uint32(p.Payload[12:]))
+	self.SuePwmInput1 = int16(binary.LittleEndian.Uint16(p.Payload[16:]))
+	self.SuePwmInput2 = int16(binary.LittleEndian.Uint16(p.Payload[18:]))
+	self.SuePwmInput3 = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
+	self.SuePwmInput4 = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
+	self.SuePwmInput5 = int16(binary.LittleEndian.Uint16(p.Payload[24:]))
+	self.SuePwmInput6 = int16(binary.LittleEndian.Uint16(p.Payload[26:]))
+	self.SuePwmInput7 = int16(binary.LittleEndian.Uint16(p.Payload[28:]))
+	self.SuePwmInput8 = int16(binary.LittleEndian.Uint16(p.Payload[30:]))
+	self.SuePwmInput9 = int16(binary.LittleEndian.Uint16(p.Payload[32:]))
+	self.SuePwmInput10 = int16(binary.LittleEndian.Uint16(p.Payload[34:]))
+	self.SuePwmInput11 = int16(binary.LittleEndian.Uint16(p.Payload[36:]))
+	self.SuePwmInput12 = int16(binary.LittleEndian.Uint16(p.Payload[38:]))
+	self.SuePwmOutput1 = int16(binary.LittleEndian.Uint16(p.Payload[40:]))
+	self.SuePwmOutput2 = int16(binary.LittleEndian.Uint16(p.Payload[42:]))
+	self.SuePwmOutput3 = int16(binary.LittleEndian.Uint16(p.Payload[44:]))
+	self.SuePwmOutput4 = int16(binary.LittleEndian.Uint16(p.Payload[46:]))
+	self.SuePwmOutput5 = int16(binary.LittleEndian.Uint16(p.Payload[48:]))
+	self.SuePwmOutput6 = int16(binary.LittleEndian.Uint16(p.Payload[50:]))
+	self.SuePwmOutput7 = int16(binary.LittleEndian.Uint16(p.Payload[52:]))
+	self.SuePwmOutput8 = int16(binary.LittleEndian.Uint16(p.Payload[54:]))
+	self.SuePwmOutput9 = int16(binary.LittleEndian.Uint16(p.Payload[56:]))
+	self.SuePwmOutput10 = int16(binary.LittleEndian.Uint16(p.Payload[58:]))
+	self.SuePwmOutput11 = int16(binary.LittleEndian.Uint16(p.Payload[60:]))
+	self.SuePwmOutput12 = int16(binary.LittleEndian.Uint16(p.Payload[62:]))
+	self.SueImuLocationX = int16(binary.LittleEndian.Uint16(p.Payload[64:]))
+	self.SueImuLocationY = int16(binary.LittleEndian.Uint16(p.Payload[66:]))
+	self.SueImuLocationZ = int16(binary.LittleEndian.Uint16(p.Payload[68:]))
+	self.SueLocationErrorEarthX = int16(binary.LittleEndian.Uint16(p.Payload[70:]))
+	self.SueLocationErrorEarthY = int16(binary.LittleEndian.Uint16(p.Payload[72:]))
+	self.SueLocationErrorEarthZ = int16(binary.LittleEndian.Uint16(p.Payload[74:]))
+	self.SueOscFails = int16(binary.LittleEndian.Uint16(p.Payload[76:]))
+	self.SueImuVelocityX = int16(binary.LittleEndian.Uint16(p.Payload[78:]))
+	self.SueImuVelocityY = int16(binary.LittleEndian.Uint16(p.Payload[80:]))
+	self.SueImuVelocityZ = int16(binary.LittleEndian.Uint16(p.Payload[82:]))
+	self.SueWaypointGoalX = int16(binary.LittleEndian.Uint16(p.Payload[84:]))
+	self.SueWaypointGoalY = int16(binary.LittleEndian.Uint16(p.Payload[86:]))
+	self.SueWaypointGoalZ = int16(binary.LittleEndian.Uint16(p.Payload[88:]))
+	self.SueAeroX = int16(binary.LittleEndian.Uint16(p.Payload[90:]))
+	self.SueAeroY = int16(binary.LittleEndian.Uint16(p.Payload[92:]))
+	self.SueAeroZ = int16(binary.LittleEndian.Uint16(p.Payload[94:]))
+	self.SueBaromTemp = int16(binary.LittleEndian.Uint16(p.Payload[96:]))
+	self.SueBatVolt = int16(binary.LittleEndian.Uint16(p.Payload[98:]))
+	self.SueBatAmp = int16(binary.LittleEndian.Uint16(p.Payload[100:]))
+	self.SueBatAmpHours = int16(binary.LittleEndian.Uint16(p.Payload[102:]))
+	self.SueDesiredHeight = int16(binary.LittleEndian.Uint16(p.Payload[104:]))
+	self.SueMemoryStackFree = int16(binary.LittleEndian.Uint16(p.Payload[106:]))
 	return nil
 }
 
@@ -651,12 +699,10 @@ func (self *SerialUdbExtraF4) Unpack(p *Packet) error {
 
 // Backwards compatible version of SERIAL_UDB_EXTRA F5: format
 type SerialUdbExtraF5 struct {
-	SueYawkpAileron            float32 // Serial UDB YAWKP_AILERON Gain for Proporional control of navigation
-	SueYawkdAileron            float32 // Serial UDB YAWKD_AILERON Gain for Rate control of navigation
-	SueRollkp                  float32 // Serial UDB Extra ROLLKP Gain for Proportional control of roll stabilization
-	SueRollkd                  float32 // Serial UDB Extra ROLLKD Gain for Rate control of roll stabilization
-	SueYawStabilizationAileron float32 // YAW_STABILIZATION_AILERON Proportional control
-	SueAileronBoost            float32 // Gain For Boosting Manual Aileron control When Plane Stabilized
+	SueYawkpAileron float32 // Serial UDB YAWKP_AILERON Gain for Proporional control of navigation
+	SueYawkdAileron float32 // Serial UDB YAWKD_AILERON Gain for Rate control of navigation
+	SueRollkp       float32 // Serial UDB Extra ROLLKP Gain for Proportional control of roll stabilization
+	SueRollkd       float32 // Serial UDB Extra ROLLKD Gain for Rate control of roll stabilization
 }
 
 func (self *SerialUdbExtraF5) MsgID() MessageID {
@@ -668,13 +714,11 @@ func (self *SerialUdbExtraF5) MsgName() string {
 }
 
 func (self *SerialUdbExtraF5) Pack(p *Packet) error {
-	payload := make([]byte, 24)
+	payload := make([]byte, 16)
 	binary.LittleEndian.PutUint32(payload[0:], math.Float32bits(self.SueYawkpAileron))
 	binary.LittleEndian.PutUint32(payload[4:], math.Float32bits(self.SueYawkdAileron))
 	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.SueRollkp))
 	binary.LittleEndian.PutUint32(payload[12:], math.Float32bits(self.SueRollkd))
-	binary.LittleEndian.PutUint32(payload[16:], math.Float32bits(self.SueYawStabilizationAileron))
-	binary.LittleEndian.PutUint32(payload[20:], math.Float32bits(self.SueAileronBoost))
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -682,15 +726,13 @@ func (self *SerialUdbExtraF5) Pack(p *Packet) error {
 }
 
 func (self *SerialUdbExtraF5) Unpack(p *Packet) error {
-	if len(p.Payload) < 24 {
+	if len(p.Payload) < 16 {
 		return fmt.Errorf("payload too small")
 	}
 	self.SueYawkpAileron = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[0:]))
 	self.SueYawkdAileron = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[4:]))
 	self.SueRollkp = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8:]))
 	self.SueRollkd = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[12:]))
-	self.SueYawStabilizationAileron = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[16:]))
-	self.SueAileronBoost = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[20:]))
 	return nil
 }
 
@@ -871,7 +913,7 @@ func (self *SerialUdbExtraF13) Unpack(p *Packet) error {
 // Backwards compatible version of SERIAL_UDB_EXTRA F14: format
 type SerialUdbExtraF14 struct {
 	SueTrapSource     uint32 // Serial UDB Extra Type Program Address of Last Trap
-	SueRcon           int16  // Serial UDB Extra Reboot Regitster of DSPIC
+	SueRcon           int16  // Serial UDB Extra Reboot Register of DSPIC
 	SueTrapFlags      int16  // Serial UDB Extra  Last dspic Trap Flags
 	SueOscFailCount   int16  // Serial UDB Extra Number of Ocillator Failures
 	SueWindEstimation uint8  // Serial UDB Extra Wind Estimation Enabled
@@ -928,7 +970,7 @@ func (self *SerialUdbExtraF14) Unpack(p *Packet) error {
 	return nil
 }
 
-// Backwards compatible version of SERIAL_UDB_EXTRA F15 and F16: format
+// Backwards compatible version of SERIAL_UDB_EXTRA F15 format
 type SerialUdbExtraF15 struct {
 	SueIdVehicleModelName    [40]uint8 // Serial UDB Extra Model Name Of Vehicle
 	SueIdVehicleRegistration [20]uint8 // Serial UDB Extra Registraton Number of Vehicle
@@ -961,7 +1003,7 @@ func (self *SerialUdbExtraF15) Unpack(p *Packet) error {
 	return nil
 }
 
-//
+// Backwards compatible version of SERIAL_UDB_EXTRA F16 format
 type SerialUdbExtraF16 struct {
 	SueIdLeadPilot    [40]uint8 // Serial UDB Extra Name of Expected Lead Pilot
 	SueIdDiyDronesUrl [70]uint8 // Serial UDB Extra URL of Lead Pilot or Team
@@ -1090,6 +1132,291 @@ func (self *Airspeeds) Unpack(p *Packet) error {
 	return nil
 }
 
+// Backwards compatible version of SERIAL_UDB_EXTRA F17 format
+type SerialUdbExtraF17 struct {
+	SueFeedForward float32 // SUE Feed Forward Gain
+	SueTurnRateNav float32 // SUE Max Turn Rate when Navigating
+	SueTurnRateFbw float32 // SUE Max Turn Rate in Fly By Wire Mode
+}
+
+func (self *SerialUdbExtraF17) MsgID() MessageID {
+	return MSG_ID_SERIAL_UDB_EXTRA_F17
+}
+
+func (self *SerialUdbExtraF17) MsgName() string {
+	return "SerialUdbExtraF17"
+}
+
+func (self *SerialUdbExtraF17) Pack(p *Packet) error {
+	payload := make([]byte, 12)
+	binary.LittleEndian.PutUint32(payload[0:], math.Float32bits(self.SueFeedForward))
+	binary.LittleEndian.PutUint32(payload[4:], math.Float32bits(self.SueTurnRateNav))
+	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.SueTurnRateFbw))
+
+	p.MsgID = self.MsgID()
+	p.Payload = payload
+	return nil
+}
+
+func (self *SerialUdbExtraF17) Unpack(p *Packet) error {
+	if len(p.Payload) < 12 {
+		return fmt.Errorf("payload too small")
+	}
+	self.SueFeedForward = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[0:]))
+	self.SueTurnRateNav = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[4:]))
+	self.SueTurnRateFbw = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8:]))
+	return nil
+}
+
+// Backwards compatible version of SERIAL_UDB_EXTRA F18 format
+type SerialUdbExtraF18 struct {
+	AngleOfAttackNormal   float32 // SUE Angle of Attack Normal
+	AngleOfAttackInverted float32 // SUE Angle of Attack Inverted
+	ElevatorTrimNormal    float32 // SUE Elevator Trim Normal
+	ElevatorTrimInverted  float32 // SUE Elevator Trim Inverted
+	ReferenceSpeed        float32 // SUE reference_speed
+}
+
+func (self *SerialUdbExtraF18) MsgID() MessageID {
+	return MSG_ID_SERIAL_UDB_EXTRA_F18
+}
+
+func (self *SerialUdbExtraF18) MsgName() string {
+	return "SerialUdbExtraF18"
+}
+
+func (self *SerialUdbExtraF18) Pack(p *Packet) error {
+	payload := make([]byte, 20)
+	binary.LittleEndian.PutUint32(payload[0:], math.Float32bits(self.AngleOfAttackNormal))
+	binary.LittleEndian.PutUint32(payload[4:], math.Float32bits(self.AngleOfAttackInverted))
+	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.ElevatorTrimNormal))
+	binary.LittleEndian.PutUint32(payload[12:], math.Float32bits(self.ElevatorTrimInverted))
+	binary.LittleEndian.PutUint32(payload[16:], math.Float32bits(self.ReferenceSpeed))
+
+	p.MsgID = self.MsgID()
+	p.Payload = payload
+	return nil
+}
+
+func (self *SerialUdbExtraF18) Unpack(p *Packet) error {
+	if len(p.Payload) < 20 {
+		return fmt.Errorf("payload too small")
+	}
+	self.AngleOfAttackNormal = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[0:]))
+	self.AngleOfAttackInverted = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[4:]))
+	self.ElevatorTrimNormal = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8:]))
+	self.ElevatorTrimInverted = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[12:]))
+	self.ReferenceSpeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[16:]))
+	return nil
+}
+
+// Backwards compatible version of SERIAL_UDB_EXTRA F19 format
+type SerialUdbExtraF19 struct {
+	SueAileronOutputChannel  uint8 // SUE aileron output channel
+	SueAileronReversed       uint8 // SUE aileron reversed
+	SueElevatorOutputChannel uint8 // SUE elevator output channel
+	SueElevatorReversed      uint8 // SUE elevator reversed
+	SueThrottleOutputChannel uint8 // SUE throttle output channel
+	SueThrottleReversed      uint8 // SUE throttle reversed
+	SueRudderOutputChannel   uint8 // SUE rudder output channel
+	SueRudderReversed        uint8 // SUE rudder reversed
+}
+
+func (self *SerialUdbExtraF19) MsgID() MessageID {
+	return MSG_ID_SERIAL_UDB_EXTRA_F19
+}
+
+func (self *SerialUdbExtraF19) MsgName() string {
+	return "SerialUdbExtraF19"
+}
+
+func (self *SerialUdbExtraF19) Pack(p *Packet) error {
+	payload := make([]byte, 8)
+	payload[0] = byte(self.SueAileronOutputChannel)
+	payload[1] = byte(self.SueAileronReversed)
+	payload[2] = byte(self.SueElevatorOutputChannel)
+	payload[3] = byte(self.SueElevatorReversed)
+	payload[4] = byte(self.SueThrottleOutputChannel)
+	payload[5] = byte(self.SueThrottleReversed)
+	payload[6] = byte(self.SueRudderOutputChannel)
+	payload[7] = byte(self.SueRudderReversed)
+
+	p.MsgID = self.MsgID()
+	p.Payload = payload
+	return nil
+}
+
+func (self *SerialUdbExtraF19) Unpack(p *Packet) error {
+	if len(p.Payload) < 8 {
+		return fmt.Errorf("payload too small")
+	}
+	self.SueAileronOutputChannel = uint8(p.Payload[0])
+	self.SueAileronReversed = uint8(p.Payload[1])
+	self.SueElevatorOutputChannel = uint8(p.Payload[2])
+	self.SueElevatorReversed = uint8(p.Payload[3])
+	self.SueThrottleOutputChannel = uint8(p.Payload[4])
+	self.SueThrottleReversed = uint8(p.Payload[5])
+	self.SueRudderOutputChannel = uint8(p.Payload[6])
+	self.SueRudderReversed = uint8(p.Payload[7])
+	return nil
+}
+
+// Backwards compatible version of SERIAL_UDB_EXTRA F20 format
+type SerialUdbExtraF20 struct {
+	SueTrimValueInput1  int16 // SUE UDB PWM Trim Value on Input 1
+	SueTrimValueInput2  int16 // SUE UDB PWM Trim Value on Input 2
+	SueTrimValueInput3  int16 // SUE UDB PWM Trim Value on Input 3
+	SueTrimValueInput4  int16 // SUE UDB PWM Trim Value on Input 4
+	SueTrimValueInput5  int16 // SUE UDB PWM Trim Value on Input 5
+	SueTrimValueInput6  int16 // SUE UDB PWM Trim Value on Input 6
+	SueTrimValueInput7  int16 // SUE UDB PWM Trim Value on Input 7
+	SueTrimValueInput8  int16 // SUE UDB PWM Trim Value on Input 8
+	SueTrimValueInput9  int16 // SUE UDB PWM Trim Value on Input 9
+	SueTrimValueInput10 int16 // SUE UDB PWM Trim Value on Input 10
+	SueTrimValueInput11 int16 // SUE UDB PWM Trim Value on Input 11
+	SueTrimValueInput12 int16 // SUE UDB PWM Trim Value on Input 12
+	SueNumberOfInputs   uint8 // SUE Number of Input Channels
+}
+
+func (self *SerialUdbExtraF20) MsgID() MessageID {
+	return MSG_ID_SERIAL_UDB_EXTRA_F20
+}
+
+func (self *SerialUdbExtraF20) MsgName() string {
+	return "SerialUdbExtraF20"
+}
+
+func (self *SerialUdbExtraF20) Pack(p *Packet) error {
+	payload := make([]byte, 25)
+	binary.LittleEndian.PutUint16(payload[0:], uint16(self.SueTrimValueInput1))
+	binary.LittleEndian.PutUint16(payload[2:], uint16(self.SueTrimValueInput2))
+	binary.LittleEndian.PutUint16(payload[4:], uint16(self.SueTrimValueInput3))
+	binary.LittleEndian.PutUint16(payload[6:], uint16(self.SueTrimValueInput4))
+	binary.LittleEndian.PutUint16(payload[8:], uint16(self.SueTrimValueInput5))
+	binary.LittleEndian.PutUint16(payload[10:], uint16(self.SueTrimValueInput6))
+	binary.LittleEndian.PutUint16(payload[12:], uint16(self.SueTrimValueInput7))
+	binary.LittleEndian.PutUint16(payload[14:], uint16(self.SueTrimValueInput8))
+	binary.LittleEndian.PutUint16(payload[16:], uint16(self.SueTrimValueInput9))
+	binary.LittleEndian.PutUint16(payload[18:], uint16(self.SueTrimValueInput10))
+	binary.LittleEndian.PutUint16(payload[20:], uint16(self.SueTrimValueInput11))
+	binary.LittleEndian.PutUint16(payload[22:], uint16(self.SueTrimValueInput12))
+	payload[24] = byte(self.SueNumberOfInputs)
+
+	p.MsgID = self.MsgID()
+	p.Payload = payload
+	return nil
+}
+
+func (self *SerialUdbExtraF20) Unpack(p *Packet) error {
+	if len(p.Payload) < 25 {
+		return fmt.Errorf("payload too small")
+	}
+	self.SueTrimValueInput1 = int16(binary.LittleEndian.Uint16(p.Payload[0:]))
+	self.SueTrimValueInput2 = int16(binary.LittleEndian.Uint16(p.Payload[2:]))
+	self.SueTrimValueInput3 = int16(binary.LittleEndian.Uint16(p.Payload[4:]))
+	self.SueTrimValueInput4 = int16(binary.LittleEndian.Uint16(p.Payload[6:]))
+	self.SueTrimValueInput5 = int16(binary.LittleEndian.Uint16(p.Payload[8:]))
+	self.SueTrimValueInput6 = int16(binary.LittleEndian.Uint16(p.Payload[10:]))
+	self.SueTrimValueInput7 = int16(binary.LittleEndian.Uint16(p.Payload[12:]))
+	self.SueTrimValueInput8 = int16(binary.LittleEndian.Uint16(p.Payload[14:]))
+	self.SueTrimValueInput9 = int16(binary.LittleEndian.Uint16(p.Payload[16:]))
+	self.SueTrimValueInput10 = int16(binary.LittleEndian.Uint16(p.Payload[18:]))
+	self.SueTrimValueInput11 = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
+	self.SueTrimValueInput12 = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
+	self.SueNumberOfInputs = uint8(p.Payload[24])
+	return nil
+}
+
+// Backwards compatible version of SERIAL_UDB_EXTRA F21 format
+type SerialUdbExtraF21 struct {
+	SueAccelXOffset int16 // SUE X accelerometer offset
+	SueAccelYOffset int16 // SUE Y accelerometer offset
+	SueAccelZOffset int16 // SUE Z accelerometer offset
+	SueGyroXOffset  int16 // SUE X gyro offset
+	SueGyroYOffset  int16 // SUE Y gyro offset
+	SueGyroZOffset  int16 // SUE Z gyro offset
+}
+
+func (self *SerialUdbExtraF21) MsgID() MessageID {
+	return MSG_ID_SERIAL_UDB_EXTRA_F21
+}
+
+func (self *SerialUdbExtraF21) MsgName() string {
+	return "SerialUdbExtraF21"
+}
+
+func (self *SerialUdbExtraF21) Pack(p *Packet) error {
+	payload := make([]byte, 12)
+	binary.LittleEndian.PutUint16(payload[0:], uint16(self.SueAccelXOffset))
+	binary.LittleEndian.PutUint16(payload[2:], uint16(self.SueAccelYOffset))
+	binary.LittleEndian.PutUint16(payload[4:], uint16(self.SueAccelZOffset))
+	binary.LittleEndian.PutUint16(payload[6:], uint16(self.SueGyroXOffset))
+	binary.LittleEndian.PutUint16(payload[8:], uint16(self.SueGyroYOffset))
+	binary.LittleEndian.PutUint16(payload[10:], uint16(self.SueGyroZOffset))
+
+	p.MsgID = self.MsgID()
+	p.Payload = payload
+	return nil
+}
+
+func (self *SerialUdbExtraF21) Unpack(p *Packet) error {
+	if len(p.Payload) < 12 {
+		return fmt.Errorf("payload too small")
+	}
+	self.SueAccelXOffset = int16(binary.LittleEndian.Uint16(p.Payload[0:]))
+	self.SueAccelYOffset = int16(binary.LittleEndian.Uint16(p.Payload[2:]))
+	self.SueAccelZOffset = int16(binary.LittleEndian.Uint16(p.Payload[4:]))
+	self.SueGyroXOffset = int16(binary.LittleEndian.Uint16(p.Payload[6:]))
+	self.SueGyroYOffset = int16(binary.LittleEndian.Uint16(p.Payload[8:]))
+	self.SueGyroZOffset = int16(binary.LittleEndian.Uint16(p.Payload[10:]))
+	return nil
+}
+
+// Backwards compatible version of SERIAL_UDB_EXTRA F22 format
+type SerialUdbExtraF22 struct {
+	SueAccelXAtCalibration int16 // SUE X accelerometer at calibration time
+	SueAccelYAtCalibration int16 // SUE Y accelerometer at calibration time
+	SueAccelZAtCalibration int16 // SUE Z accelerometer at calibration time
+	SueGyroXAtCalibration  int16 // SUE X gyro at calibration time
+	SueGyroYAtCalibration  int16 // SUE Y gyro at calibration time
+	SueGyroZAtCalibration  int16 // SUE Z gyro at calibration time
+}
+
+func (self *SerialUdbExtraF22) MsgID() MessageID {
+	return MSG_ID_SERIAL_UDB_EXTRA_F22
+}
+
+func (self *SerialUdbExtraF22) MsgName() string {
+	return "SerialUdbExtraF22"
+}
+
+func (self *SerialUdbExtraF22) Pack(p *Packet) error {
+	payload := make([]byte, 12)
+	binary.LittleEndian.PutUint16(payload[0:], uint16(self.SueAccelXAtCalibration))
+	binary.LittleEndian.PutUint16(payload[2:], uint16(self.SueAccelYAtCalibration))
+	binary.LittleEndian.PutUint16(payload[4:], uint16(self.SueAccelZAtCalibration))
+	binary.LittleEndian.PutUint16(payload[6:], uint16(self.SueGyroXAtCalibration))
+	binary.LittleEndian.PutUint16(payload[8:], uint16(self.SueGyroYAtCalibration))
+	binary.LittleEndian.PutUint16(payload[10:], uint16(self.SueGyroZAtCalibration))
+
+	p.MsgID = self.MsgID()
+	p.Payload = payload
+	return nil
+}
+
+func (self *SerialUdbExtraF22) Unpack(p *Packet) error {
+	if len(p.Payload) < 12 {
+		return fmt.Errorf("payload too small")
+	}
+	self.SueAccelXAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[0:]))
+	self.SueAccelYAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[2:]))
+	self.SueAccelZAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[4:]))
+	self.SueGyroXAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[6:]))
+	self.SueGyroYAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[8:]))
+	self.SueGyroZAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[10:]))
+	return nil
+}
+
 // Message IDs
 const (
 	MSG_ID_FLEXIFUNCTION_SET                 MessageID = 150
@@ -1113,6 +1440,12 @@ const (
 	MSG_ID_SERIAL_UDB_EXTRA_F16              MessageID = 180
 	MSG_ID_ALTITUDES                         MessageID = 181
 	MSG_ID_AIRSPEEDS                         MessageID = 182
+	MSG_ID_SERIAL_UDB_EXTRA_F17              MessageID = 183
+	MSG_ID_SERIAL_UDB_EXTRA_F18              MessageID = 184
+	MSG_ID_SERIAL_UDB_EXTRA_F19              MessageID = 185
+	MSG_ID_SERIAL_UDB_EXTRA_F20              MessageID = 186
+	MSG_ID_SERIAL_UDB_EXTRA_F21              MessageID = 187
+	MSG_ID_SERIAL_UDB_EXTRA_F22              MessageID = 188
 )
 
 // DialectMatrixpilot is the dialect represented by matrixpilot.xml
@@ -1127,10 +1460,10 @@ var DialectMatrixpilot *Dialect = &Dialect{
 		MSG_ID_FLEXIFUNCTION_DIRECTORY_ACK:       218,
 		MSG_ID_FLEXIFUNCTION_COMMAND:             133,
 		MSG_ID_FLEXIFUNCTION_COMMAND_ACK:         208,
-		MSG_ID_SERIAL_UDB_EXTRA_F2_A:             150,
-		MSG_ID_SERIAL_UDB_EXTRA_F2_B:             169,
+		MSG_ID_SERIAL_UDB_EXTRA_F2_A:             103,
+		MSG_ID_SERIAL_UDB_EXTRA_F2_B:             245,
 		MSG_ID_SERIAL_UDB_EXTRA_F4:               191,
-		MSG_ID_SERIAL_UDB_EXTRA_F5:               121,
+		MSG_ID_SERIAL_UDB_EXTRA_F5:               54,
 		MSG_ID_SERIAL_UDB_EXTRA_F6:               54,
 		MSG_ID_SERIAL_UDB_EXTRA_F7:               171,
 		MSG_ID_SERIAL_UDB_EXTRA_F8:               142,
@@ -1140,6 +1473,12 @@ var DialectMatrixpilot *Dialect = &Dialect{
 		MSG_ID_SERIAL_UDB_EXTRA_F16:              222,
 		MSG_ID_ALTITUDES:                         55,
 		MSG_ID_AIRSPEEDS:                         154,
+		MSG_ID_SERIAL_UDB_EXTRA_F17:              175,
+		MSG_ID_SERIAL_UDB_EXTRA_F18:              41,
+		MSG_ID_SERIAL_UDB_EXTRA_F19:              87,
+		MSG_ID_SERIAL_UDB_EXTRA_F20:              144,
+		MSG_ID_SERIAL_UDB_EXTRA_F21:              134,
+		MSG_ID_SERIAL_UDB_EXTRA_F22:              91,
 	},
 	messageConstructorByMsgId: map[MessageID]func(*Packet) Message{
 		MSG_ID_FLEXIFUNCTION_SET: func(pkt *Packet) Message {
@@ -1244,6 +1583,36 @@ var DialectMatrixpilot *Dialect = &Dialect{
 		},
 		MSG_ID_AIRSPEEDS: func(pkt *Packet) Message {
 			msg := new(Airspeeds)
+			msg.Unpack(pkt)
+			return msg
+		},
+		MSG_ID_SERIAL_UDB_EXTRA_F17: func(pkt *Packet) Message {
+			msg := new(SerialUdbExtraF17)
+			msg.Unpack(pkt)
+			return msg
+		},
+		MSG_ID_SERIAL_UDB_EXTRA_F18: func(pkt *Packet) Message {
+			msg := new(SerialUdbExtraF18)
+			msg.Unpack(pkt)
+			return msg
+		},
+		MSG_ID_SERIAL_UDB_EXTRA_F19: func(pkt *Packet) Message {
+			msg := new(SerialUdbExtraF19)
+			msg.Unpack(pkt)
+			return msg
+		},
+		MSG_ID_SERIAL_UDB_EXTRA_F20: func(pkt *Packet) Message {
+			msg := new(SerialUdbExtraF20)
+			msg.Unpack(pkt)
+			return msg
+		},
+		MSG_ID_SERIAL_UDB_EXTRA_F21: func(pkt *Packet) Message {
+			msg := new(SerialUdbExtraF21)
+			msg.Unpack(pkt)
+			return msg
+		},
+		MSG_ID_SERIAL_UDB_EXTRA_F22: func(pkt *Packet) Message {
+			msg := new(SerialUdbExtraF22)
 			msg.Unpack(pkt)
 			return msg
 		},

--- a/mavlink/matrixpilot.go
+++ b/mavlink/matrixpilot.go
@@ -374,6 +374,7 @@ type SerialUdbExtraF2A struct {
 	SueCog            uint16 // Serial UDB Extra GPS Course Over Ground
 	SueSog            int16  // Serial UDB Extra Speed Over Ground
 	SueCpuLoad        uint16 // Serial UDB Extra CPU Load
+	SueVoltageMilis   int16  // Serial UDB Extra Voltage in MilliVolts
 	SueAirSpeed3dimu  uint16 // Serial UDB Extra 3D IMU Air Speed
 	SueEstimatedWind0 int16  // Serial UDB Extra Estimated Wind 0
 	SueEstimatedWind1 int16  // Serial UDB Extra Estimated Wind 1
@@ -395,7 +396,7 @@ func (self *SerialUdbExtraF2A) MsgName() string {
 }
 
 func (self *SerialUdbExtraF2A) Pack(p *Packet) error {
-	payload := make([]byte, 61)
+	payload := make([]byte, 63)
 	binary.LittleEndian.PutUint32(payload[0:], uint32(self.SueTime))
 	binary.LittleEndian.PutUint32(payload[4:], uint32(self.SueLatitude))
 	binary.LittleEndian.PutUint32(payload[8:], uint32(self.SueLongitude))
@@ -413,16 +414,17 @@ func (self *SerialUdbExtraF2A) Pack(p *Packet) error {
 	binary.LittleEndian.PutUint16(payload[36:], uint16(self.SueCog))
 	binary.LittleEndian.PutUint16(payload[38:], uint16(self.SueSog))
 	binary.LittleEndian.PutUint16(payload[40:], uint16(self.SueCpuLoad))
-	binary.LittleEndian.PutUint16(payload[42:], uint16(self.SueAirSpeed3dimu))
-	binary.LittleEndian.PutUint16(payload[44:], uint16(self.SueEstimatedWind0))
-	binary.LittleEndian.PutUint16(payload[46:], uint16(self.SueEstimatedWind1))
-	binary.LittleEndian.PutUint16(payload[48:], uint16(self.SueEstimatedWind2))
-	binary.LittleEndian.PutUint16(payload[50:], uint16(self.SueMagfieldearth0))
-	binary.LittleEndian.PutUint16(payload[52:], uint16(self.SueMagfieldearth1))
-	binary.LittleEndian.PutUint16(payload[54:], uint16(self.SueMagfieldearth2))
-	binary.LittleEndian.PutUint16(payload[56:], uint16(self.SueSvs))
-	binary.LittleEndian.PutUint16(payload[58:], uint16(self.SueHdop))
-	payload[60] = byte(self.SueStatus)
+	binary.LittleEndian.PutUint16(payload[42:], uint16(self.SueVoltageMilis))
+	binary.LittleEndian.PutUint16(payload[44:], uint16(self.SueAirSpeed3dimu))
+	binary.LittleEndian.PutUint16(payload[46:], uint16(self.SueEstimatedWind0))
+	binary.LittleEndian.PutUint16(payload[48:], uint16(self.SueEstimatedWind1))
+	binary.LittleEndian.PutUint16(payload[50:], uint16(self.SueEstimatedWind2))
+	binary.LittleEndian.PutUint16(payload[52:], uint16(self.SueMagfieldearth0))
+	binary.LittleEndian.PutUint16(payload[54:], uint16(self.SueMagfieldearth1))
+	binary.LittleEndian.PutUint16(payload[56:], uint16(self.SueMagfieldearth2))
+	binary.LittleEndian.PutUint16(payload[58:], uint16(self.SueSvs))
+	binary.LittleEndian.PutUint16(payload[60:], uint16(self.SueHdop))
+	payload[62] = byte(self.SueStatus)
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -430,7 +432,7 @@ func (self *SerialUdbExtraF2A) Pack(p *Packet) error {
 }
 
 func (self *SerialUdbExtraF2A) Unpack(p *Packet) error {
-	if len(p.Payload) < 61 {
+	if len(p.Payload) < 63 {
 		return fmt.Errorf("payload too small")
 	}
 	self.SueTime = uint32(binary.LittleEndian.Uint32(p.Payload[0:]))
@@ -450,71 +452,55 @@ func (self *SerialUdbExtraF2A) Unpack(p *Packet) error {
 	self.SueCog = uint16(binary.LittleEndian.Uint16(p.Payload[36:]))
 	self.SueSog = int16(binary.LittleEndian.Uint16(p.Payload[38:]))
 	self.SueCpuLoad = uint16(binary.LittleEndian.Uint16(p.Payload[40:]))
-	self.SueAirSpeed3dimu = uint16(binary.LittleEndian.Uint16(p.Payload[42:]))
-	self.SueEstimatedWind0 = int16(binary.LittleEndian.Uint16(p.Payload[44:]))
-	self.SueEstimatedWind1 = int16(binary.LittleEndian.Uint16(p.Payload[46:]))
-	self.SueEstimatedWind2 = int16(binary.LittleEndian.Uint16(p.Payload[48:]))
-	self.SueMagfieldearth0 = int16(binary.LittleEndian.Uint16(p.Payload[50:]))
-	self.SueMagfieldearth1 = int16(binary.LittleEndian.Uint16(p.Payload[52:]))
-	self.SueMagfieldearth2 = int16(binary.LittleEndian.Uint16(p.Payload[54:]))
-	self.SueSvs = int16(binary.LittleEndian.Uint16(p.Payload[56:]))
-	self.SueHdop = int16(binary.LittleEndian.Uint16(p.Payload[58:]))
-	self.SueStatus = uint8(p.Payload[60])
+	self.SueVoltageMilis = int16(binary.LittleEndian.Uint16(p.Payload[42:]))
+	self.SueAirSpeed3dimu = uint16(binary.LittleEndian.Uint16(p.Payload[44:]))
+	self.SueEstimatedWind0 = int16(binary.LittleEndian.Uint16(p.Payload[46:]))
+	self.SueEstimatedWind1 = int16(binary.LittleEndian.Uint16(p.Payload[48:]))
+	self.SueEstimatedWind2 = int16(binary.LittleEndian.Uint16(p.Payload[50:]))
+	self.SueMagfieldearth0 = int16(binary.LittleEndian.Uint16(p.Payload[52:]))
+	self.SueMagfieldearth1 = int16(binary.LittleEndian.Uint16(p.Payload[54:]))
+	self.SueMagfieldearth2 = int16(binary.LittleEndian.Uint16(p.Payload[56:]))
+	self.SueSvs = int16(binary.LittleEndian.Uint16(p.Payload[58:]))
+	self.SueHdop = int16(binary.LittleEndian.Uint16(p.Payload[60:]))
+	self.SueStatus = uint8(p.Payload[62])
 	return nil
 }
 
 // Backwards compatible version of SERIAL_UDB_EXTRA - F2: Part B
 type SerialUdbExtraF2B struct {
-	SueTime                uint32 // Serial UDB Extra Time
-	SueFlags               uint32 // Serial UDB Extra Status Flags
-	SueBaromPress          int32  // SUE barometer pressure
-	SueBaromAlt            int32  // SUE barometer altitude
-	SuePwmInput1           int16  // Serial UDB Extra PWM Input Channel 1
-	SuePwmInput2           int16  // Serial UDB Extra PWM Input Channel 2
-	SuePwmInput3           int16  // Serial UDB Extra PWM Input Channel 3
-	SuePwmInput4           int16  // Serial UDB Extra PWM Input Channel 4
-	SuePwmInput5           int16  // Serial UDB Extra PWM Input Channel 5
-	SuePwmInput6           int16  // Serial UDB Extra PWM Input Channel 6
-	SuePwmInput7           int16  // Serial UDB Extra PWM Input Channel 7
-	SuePwmInput8           int16  // Serial UDB Extra PWM Input Channel 8
-	SuePwmInput9           int16  // Serial UDB Extra PWM Input Channel 9
-	SuePwmInput10          int16  // Serial UDB Extra PWM Input Channel 10
-	SuePwmInput11          int16  // Serial UDB Extra PWM Input Channel 11
-	SuePwmInput12          int16  // Serial UDB Extra PWM Input Channel 12
-	SuePwmOutput1          int16  // Serial UDB Extra PWM Output Channel 1
-	SuePwmOutput2          int16  // Serial UDB Extra PWM Output Channel 2
-	SuePwmOutput3          int16  // Serial UDB Extra PWM Output Channel 3
-	SuePwmOutput4          int16  // Serial UDB Extra PWM Output Channel 4
-	SuePwmOutput5          int16  // Serial UDB Extra PWM Output Channel 5
-	SuePwmOutput6          int16  // Serial UDB Extra PWM Output Channel 6
-	SuePwmOutput7          int16  // Serial UDB Extra PWM Output Channel 7
-	SuePwmOutput8          int16  // Serial UDB Extra PWM Output Channel 8
-	SuePwmOutput9          int16  // Serial UDB Extra PWM Output Channel 9
-	SuePwmOutput10         int16  // Serial UDB Extra PWM Output Channel 10
-	SuePwmOutput11         int16  // Serial UDB Extra PWM Output Channel 11
-	SuePwmOutput12         int16  // Serial UDB Extra PWM Output Channel 12
-	SueImuLocationX        int16  // Serial UDB Extra IMU Location X
-	SueImuLocationY        int16  // Serial UDB Extra IMU Location Y
-	SueImuLocationZ        int16  // Serial UDB Extra IMU Location Z
-	SueLocationErrorEarthX int16  // Serial UDB Location Error Earth X
-	SueLocationErrorEarthY int16  // Serial UDB Location Error Earth Y
-	SueLocationErrorEarthZ int16  // Serial UDB Location Error Earth Z
-	SueOscFails            int16  // Serial UDB Extra Oscillator Failure Count
-	SueImuVelocityX        int16  // Serial UDB Extra IMU Velocity X
-	SueImuVelocityY        int16  // Serial UDB Extra IMU Velocity Y
-	SueImuVelocityZ        int16  // Serial UDB Extra IMU Velocity Z
-	SueWaypointGoalX       int16  // Serial UDB Extra Current Waypoint Goal X
-	SueWaypointGoalY       int16  // Serial UDB Extra Current Waypoint Goal Y
-	SueWaypointGoalZ       int16  // Serial UDB Extra Current Waypoint Goal Z
-	SueAeroX               int16  // Aeroforce in UDB X Axis
-	SueAeroY               int16  // Aeroforce in UDB Y Axis
-	SueAeroZ               int16  // Aeroforce in UDB Z axis
-	SueBaromTemp           int16  // SUE barometer temperature
-	SueBatVolt             int16  // SUE battery voltage
-	SueBatAmp              int16  // SUE battery current
-	SueBatAmpHours         int16  // SUE battery milli amp hours used
-	SueDesiredHeight       int16  // Sue autopilot desired height
-	SueMemoryStackFree     int16  // Serial UDB Extra Stack Memory Free
+	SueTime            uint32 // Serial UDB Extra Time
+	SueFlags           uint32 // Serial UDB Extra Status Flags
+	SuePwmInput1       int16  // Serial UDB Extra PWM Input Channel 1
+	SuePwmInput2       int16  // Serial UDB Extra PWM Input Channel 2
+	SuePwmInput3       int16  // Serial UDB Extra PWM Input Channel 3
+	SuePwmInput4       int16  // Serial UDB Extra PWM Input Channel 4
+	SuePwmInput5       int16  // Serial UDB Extra PWM Input Channel 5
+	SuePwmInput6       int16  // Serial UDB Extra PWM Input Channel 6
+	SuePwmInput7       int16  // Serial UDB Extra PWM Input Channel 7
+	SuePwmInput8       int16  // Serial UDB Extra PWM Input Channel 8
+	SuePwmInput9       int16  // Serial UDB Extra PWM Input Channel 9
+	SuePwmInput10      int16  // Serial UDB Extra PWM Input Channel 10
+	SuePwmOutput1      int16  // Serial UDB Extra PWM Output Channel 1
+	SuePwmOutput2      int16  // Serial UDB Extra PWM Output Channel 2
+	SuePwmOutput3      int16  // Serial UDB Extra PWM Output Channel 3
+	SuePwmOutput4      int16  // Serial UDB Extra PWM Output Channel 4
+	SuePwmOutput5      int16  // Serial UDB Extra PWM Output Channel 5
+	SuePwmOutput6      int16  // Serial UDB Extra PWM Output Channel 6
+	SuePwmOutput7      int16  // Serial UDB Extra PWM Output Channel 7
+	SuePwmOutput8      int16  // Serial UDB Extra PWM Output Channel 8
+	SuePwmOutput9      int16  // Serial UDB Extra PWM Output Channel 9
+	SuePwmOutput10     int16  // Serial UDB Extra PWM Output Channel 10
+	SueImuLocationX    int16  // Serial UDB Extra IMU Location X
+	SueImuLocationY    int16  // Serial UDB Extra IMU Location Y
+	SueImuLocationZ    int16  // Serial UDB Extra IMU Location Z
+	SueOscFails        int16  // Serial UDB Extra Oscillator Failure Count
+	SueImuVelocityX    int16  // Serial UDB Extra IMU Velocity X
+	SueImuVelocityY    int16  // Serial UDB Extra IMU Velocity Y
+	SueImuVelocityZ    int16  // Serial UDB Extra IMU Velocity Z
+	SueWaypointGoalX   int16  // Serial UDB Extra Current Waypoint Goal X
+	SueWaypointGoalY   int16  // Serial UDB Extra Current Waypoint Goal Y
+	SueWaypointGoalZ   int16  // Serial UDB Extra Current Waypoint Goal Z
+	SueMemoryStackFree int16  // Serial UDB Extra Stack Memory Free
 }
 
 func (self *SerialUdbExtraF2B) MsgID() MessageID {
@@ -526,57 +512,40 @@ func (self *SerialUdbExtraF2B) MsgName() string {
 }
 
 func (self *SerialUdbExtraF2B) Pack(p *Packet) error {
-	payload := make([]byte, 108)
+	payload := make([]byte, 70)
 	binary.LittleEndian.PutUint32(payload[0:], uint32(self.SueTime))
 	binary.LittleEndian.PutUint32(payload[4:], uint32(self.SueFlags))
-	binary.LittleEndian.PutUint32(payload[8:], uint32(self.SueBaromPress))
-	binary.LittleEndian.PutUint32(payload[12:], uint32(self.SueBaromAlt))
-	binary.LittleEndian.PutUint16(payload[16:], uint16(self.SuePwmInput1))
-	binary.LittleEndian.PutUint16(payload[18:], uint16(self.SuePwmInput2))
-	binary.LittleEndian.PutUint16(payload[20:], uint16(self.SuePwmInput3))
-	binary.LittleEndian.PutUint16(payload[22:], uint16(self.SuePwmInput4))
-	binary.LittleEndian.PutUint16(payload[24:], uint16(self.SuePwmInput5))
-	binary.LittleEndian.PutUint16(payload[26:], uint16(self.SuePwmInput6))
-	binary.LittleEndian.PutUint16(payload[28:], uint16(self.SuePwmInput7))
-	binary.LittleEndian.PutUint16(payload[30:], uint16(self.SuePwmInput8))
-	binary.LittleEndian.PutUint16(payload[32:], uint16(self.SuePwmInput9))
-	binary.LittleEndian.PutUint16(payload[34:], uint16(self.SuePwmInput10))
-	binary.LittleEndian.PutUint16(payload[36:], uint16(self.SuePwmInput11))
-	binary.LittleEndian.PutUint16(payload[38:], uint16(self.SuePwmInput12))
-	binary.LittleEndian.PutUint16(payload[40:], uint16(self.SuePwmOutput1))
-	binary.LittleEndian.PutUint16(payload[42:], uint16(self.SuePwmOutput2))
-	binary.LittleEndian.PutUint16(payload[44:], uint16(self.SuePwmOutput3))
-	binary.LittleEndian.PutUint16(payload[46:], uint16(self.SuePwmOutput4))
-	binary.LittleEndian.PutUint16(payload[48:], uint16(self.SuePwmOutput5))
-	binary.LittleEndian.PutUint16(payload[50:], uint16(self.SuePwmOutput6))
-	binary.LittleEndian.PutUint16(payload[52:], uint16(self.SuePwmOutput7))
-	binary.LittleEndian.PutUint16(payload[54:], uint16(self.SuePwmOutput8))
-	binary.LittleEndian.PutUint16(payload[56:], uint16(self.SuePwmOutput9))
-	binary.LittleEndian.PutUint16(payload[58:], uint16(self.SuePwmOutput10))
-	binary.LittleEndian.PutUint16(payload[60:], uint16(self.SuePwmOutput11))
-	binary.LittleEndian.PutUint16(payload[62:], uint16(self.SuePwmOutput12))
-	binary.LittleEndian.PutUint16(payload[64:], uint16(self.SueImuLocationX))
-	binary.LittleEndian.PutUint16(payload[66:], uint16(self.SueImuLocationY))
-	binary.LittleEndian.PutUint16(payload[68:], uint16(self.SueImuLocationZ))
-	binary.LittleEndian.PutUint16(payload[70:], uint16(self.SueLocationErrorEarthX))
-	binary.LittleEndian.PutUint16(payload[72:], uint16(self.SueLocationErrorEarthY))
-	binary.LittleEndian.PutUint16(payload[74:], uint16(self.SueLocationErrorEarthZ))
-	binary.LittleEndian.PutUint16(payload[76:], uint16(self.SueOscFails))
-	binary.LittleEndian.PutUint16(payload[78:], uint16(self.SueImuVelocityX))
-	binary.LittleEndian.PutUint16(payload[80:], uint16(self.SueImuVelocityY))
-	binary.LittleEndian.PutUint16(payload[82:], uint16(self.SueImuVelocityZ))
-	binary.LittleEndian.PutUint16(payload[84:], uint16(self.SueWaypointGoalX))
-	binary.LittleEndian.PutUint16(payload[86:], uint16(self.SueWaypointGoalY))
-	binary.LittleEndian.PutUint16(payload[88:], uint16(self.SueWaypointGoalZ))
-	binary.LittleEndian.PutUint16(payload[90:], uint16(self.SueAeroX))
-	binary.LittleEndian.PutUint16(payload[92:], uint16(self.SueAeroY))
-	binary.LittleEndian.PutUint16(payload[94:], uint16(self.SueAeroZ))
-	binary.LittleEndian.PutUint16(payload[96:], uint16(self.SueBaromTemp))
-	binary.LittleEndian.PutUint16(payload[98:], uint16(self.SueBatVolt))
-	binary.LittleEndian.PutUint16(payload[100:], uint16(self.SueBatAmp))
-	binary.LittleEndian.PutUint16(payload[102:], uint16(self.SueBatAmpHours))
-	binary.LittleEndian.PutUint16(payload[104:], uint16(self.SueDesiredHeight))
-	binary.LittleEndian.PutUint16(payload[106:], uint16(self.SueMemoryStackFree))
+	binary.LittleEndian.PutUint16(payload[8:], uint16(self.SuePwmInput1))
+	binary.LittleEndian.PutUint16(payload[10:], uint16(self.SuePwmInput2))
+	binary.LittleEndian.PutUint16(payload[12:], uint16(self.SuePwmInput3))
+	binary.LittleEndian.PutUint16(payload[14:], uint16(self.SuePwmInput4))
+	binary.LittleEndian.PutUint16(payload[16:], uint16(self.SuePwmInput5))
+	binary.LittleEndian.PutUint16(payload[18:], uint16(self.SuePwmInput6))
+	binary.LittleEndian.PutUint16(payload[20:], uint16(self.SuePwmInput7))
+	binary.LittleEndian.PutUint16(payload[22:], uint16(self.SuePwmInput8))
+	binary.LittleEndian.PutUint16(payload[24:], uint16(self.SuePwmInput9))
+	binary.LittleEndian.PutUint16(payload[26:], uint16(self.SuePwmInput10))
+	binary.LittleEndian.PutUint16(payload[28:], uint16(self.SuePwmOutput1))
+	binary.LittleEndian.PutUint16(payload[30:], uint16(self.SuePwmOutput2))
+	binary.LittleEndian.PutUint16(payload[32:], uint16(self.SuePwmOutput3))
+	binary.LittleEndian.PutUint16(payload[34:], uint16(self.SuePwmOutput4))
+	binary.LittleEndian.PutUint16(payload[36:], uint16(self.SuePwmOutput5))
+	binary.LittleEndian.PutUint16(payload[38:], uint16(self.SuePwmOutput6))
+	binary.LittleEndian.PutUint16(payload[40:], uint16(self.SuePwmOutput7))
+	binary.LittleEndian.PutUint16(payload[42:], uint16(self.SuePwmOutput8))
+	binary.LittleEndian.PutUint16(payload[44:], uint16(self.SuePwmOutput9))
+	binary.LittleEndian.PutUint16(payload[46:], uint16(self.SuePwmOutput10))
+	binary.LittleEndian.PutUint16(payload[48:], uint16(self.SueImuLocationX))
+	binary.LittleEndian.PutUint16(payload[50:], uint16(self.SueImuLocationY))
+	binary.LittleEndian.PutUint16(payload[52:], uint16(self.SueImuLocationZ))
+	binary.LittleEndian.PutUint16(payload[54:], uint16(self.SueOscFails))
+	binary.LittleEndian.PutUint16(payload[56:], uint16(self.SueImuVelocityX))
+	binary.LittleEndian.PutUint16(payload[58:], uint16(self.SueImuVelocityY))
+	binary.LittleEndian.PutUint16(payload[60:], uint16(self.SueImuVelocityZ))
+	binary.LittleEndian.PutUint16(payload[62:], uint16(self.SueWaypointGoalX))
+	binary.LittleEndian.PutUint16(payload[64:], uint16(self.SueWaypointGoalY))
+	binary.LittleEndian.PutUint16(payload[66:], uint16(self.SueWaypointGoalZ))
+	binary.LittleEndian.PutUint16(payload[68:], uint16(self.SueMemoryStackFree))
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -584,59 +553,42 @@ func (self *SerialUdbExtraF2B) Pack(p *Packet) error {
 }
 
 func (self *SerialUdbExtraF2B) Unpack(p *Packet) error {
-	if len(p.Payload) < 108 {
+	if len(p.Payload) < 70 {
 		return fmt.Errorf("payload too small")
 	}
 	self.SueTime = uint32(binary.LittleEndian.Uint32(p.Payload[0:]))
 	self.SueFlags = uint32(binary.LittleEndian.Uint32(p.Payload[4:]))
-	self.SueBaromPress = int32(binary.LittleEndian.Uint32(p.Payload[8:]))
-	self.SueBaromAlt = int32(binary.LittleEndian.Uint32(p.Payload[12:]))
-	self.SuePwmInput1 = int16(binary.LittleEndian.Uint16(p.Payload[16:]))
-	self.SuePwmInput2 = int16(binary.LittleEndian.Uint16(p.Payload[18:]))
-	self.SuePwmInput3 = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
-	self.SuePwmInput4 = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
-	self.SuePwmInput5 = int16(binary.LittleEndian.Uint16(p.Payload[24:]))
-	self.SuePwmInput6 = int16(binary.LittleEndian.Uint16(p.Payload[26:]))
-	self.SuePwmInput7 = int16(binary.LittleEndian.Uint16(p.Payload[28:]))
-	self.SuePwmInput8 = int16(binary.LittleEndian.Uint16(p.Payload[30:]))
-	self.SuePwmInput9 = int16(binary.LittleEndian.Uint16(p.Payload[32:]))
-	self.SuePwmInput10 = int16(binary.LittleEndian.Uint16(p.Payload[34:]))
-	self.SuePwmInput11 = int16(binary.LittleEndian.Uint16(p.Payload[36:]))
-	self.SuePwmInput12 = int16(binary.LittleEndian.Uint16(p.Payload[38:]))
-	self.SuePwmOutput1 = int16(binary.LittleEndian.Uint16(p.Payload[40:]))
-	self.SuePwmOutput2 = int16(binary.LittleEndian.Uint16(p.Payload[42:]))
-	self.SuePwmOutput3 = int16(binary.LittleEndian.Uint16(p.Payload[44:]))
-	self.SuePwmOutput4 = int16(binary.LittleEndian.Uint16(p.Payload[46:]))
-	self.SuePwmOutput5 = int16(binary.LittleEndian.Uint16(p.Payload[48:]))
-	self.SuePwmOutput6 = int16(binary.LittleEndian.Uint16(p.Payload[50:]))
-	self.SuePwmOutput7 = int16(binary.LittleEndian.Uint16(p.Payload[52:]))
-	self.SuePwmOutput8 = int16(binary.LittleEndian.Uint16(p.Payload[54:]))
-	self.SuePwmOutput9 = int16(binary.LittleEndian.Uint16(p.Payload[56:]))
-	self.SuePwmOutput10 = int16(binary.LittleEndian.Uint16(p.Payload[58:]))
-	self.SuePwmOutput11 = int16(binary.LittleEndian.Uint16(p.Payload[60:]))
-	self.SuePwmOutput12 = int16(binary.LittleEndian.Uint16(p.Payload[62:]))
-	self.SueImuLocationX = int16(binary.LittleEndian.Uint16(p.Payload[64:]))
-	self.SueImuLocationY = int16(binary.LittleEndian.Uint16(p.Payload[66:]))
-	self.SueImuLocationZ = int16(binary.LittleEndian.Uint16(p.Payload[68:]))
-	self.SueLocationErrorEarthX = int16(binary.LittleEndian.Uint16(p.Payload[70:]))
-	self.SueLocationErrorEarthY = int16(binary.LittleEndian.Uint16(p.Payload[72:]))
-	self.SueLocationErrorEarthZ = int16(binary.LittleEndian.Uint16(p.Payload[74:]))
-	self.SueOscFails = int16(binary.LittleEndian.Uint16(p.Payload[76:]))
-	self.SueImuVelocityX = int16(binary.LittleEndian.Uint16(p.Payload[78:]))
-	self.SueImuVelocityY = int16(binary.LittleEndian.Uint16(p.Payload[80:]))
-	self.SueImuVelocityZ = int16(binary.LittleEndian.Uint16(p.Payload[82:]))
-	self.SueWaypointGoalX = int16(binary.LittleEndian.Uint16(p.Payload[84:]))
-	self.SueWaypointGoalY = int16(binary.LittleEndian.Uint16(p.Payload[86:]))
-	self.SueWaypointGoalZ = int16(binary.LittleEndian.Uint16(p.Payload[88:]))
-	self.SueAeroX = int16(binary.LittleEndian.Uint16(p.Payload[90:]))
-	self.SueAeroY = int16(binary.LittleEndian.Uint16(p.Payload[92:]))
-	self.SueAeroZ = int16(binary.LittleEndian.Uint16(p.Payload[94:]))
-	self.SueBaromTemp = int16(binary.LittleEndian.Uint16(p.Payload[96:]))
-	self.SueBatVolt = int16(binary.LittleEndian.Uint16(p.Payload[98:]))
-	self.SueBatAmp = int16(binary.LittleEndian.Uint16(p.Payload[100:]))
-	self.SueBatAmpHours = int16(binary.LittleEndian.Uint16(p.Payload[102:]))
-	self.SueDesiredHeight = int16(binary.LittleEndian.Uint16(p.Payload[104:]))
-	self.SueMemoryStackFree = int16(binary.LittleEndian.Uint16(p.Payload[106:]))
+	self.SuePwmInput1 = int16(binary.LittleEndian.Uint16(p.Payload[8:]))
+	self.SuePwmInput2 = int16(binary.LittleEndian.Uint16(p.Payload[10:]))
+	self.SuePwmInput3 = int16(binary.LittleEndian.Uint16(p.Payload[12:]))
+	self.SuePwmInput4 = int16(binary.LittleEndian.Uint16(p.Payload[14:]))
+	self.SuePwmInput5 = int16(binary.LittleEndian.Uint16(p.Payload[16:]))
+	self.SuePwmInput6 = int16(binary.LittleEndian.Uint16(p.Payload[18:]))
+	self.SuePwmInput7 = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
+	self.SuePwmInput8 = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
+	self.SuePwmInput9 = int16(binary.LittleEndian.Uint16(p.Payload[24:]))
+	self.SuePwmInput10 = int16(binary.LittleEndian.Uint16(p.Payload[26:]))
+	self.SuePwmOutput1 = int16(binary.LittleEndian.Uint16(p.Payload[28:]))
+	self.SuePwmOutput2 = int16(binary.LittleEndian.Uint16(p.Payload[30:]))
+	self.SuePwmOutput3 = int16(binary.LittleEndian.Uint16(p.Payload[32:]))
+	self.SuePwmOutput4 = int16(binary.LittleEndian.Uint16(p.Payload[34:]))
+	self.SuePwmOutput5 = int16(binary.LittleEndian.Uint16(p.Payload[36:]))
+	self.SuePwmOutput6 = int16(binary.LittleEndian.Uint16(p.Payload[38:]))
+	self.SuePwmOutput7 = int16(binary.LittleEndian.Uint16(p.Payload[40:]))
+	self.SuePwmOutput8 = int16(binary.LittleEndian.Uint16(p.Payload[42:]))
+	self.SuePwmOutput9 = int16(binary.LittleEndian.Uint16(p.Payload[44:]))
+	self.SuePwmOutput10 = int16(binary.LittleEndian.Uint16(p.Payload[46:]))
+	self.SueImuLocationX = int16(binary.LittleEndian.Uint16(p.Payload[48:]))
+	self.SueImuLocationY = int16(binary.LittleEndian.Uint16(p.Payload[50:]))
+	self.SueImuLocationZ = int16(binary.LittleEndian.Uint16(p.Payload[52:]))
+	self.SueOscFails = int16(binary.LittleEndian.Uint16(p.Payload[54:]))
+	self.SueImuVelocityX = int16(binary.LittleEndian.Uint16(p.Payload[56:]))
+	self.SueImuVelocityY = int16(binary.LittleEndian.Uint16(p.Payload[58:]))
+	self.SueImuVelocityZ = int16(binary.LittleEndian.Uint16(p.Payload[60:]))
+	self.SueWaypointGoalX = int16(binary.LittleEndian.Uint16(p.Payload[62:]))
+	self.SueWaypointGoalY = int16(binary.LittleEndian.Uint16(p.Payload[64:]))
+	self.SueWaypointGoalZ = int16(binary.LittleEndian.Uint16(p.Payload[66:]))
+	self.SueMemoryStackFree = int16(binary.LittleEndian.Uint16(p.Payload[68:]))
 	return nil
 }
 
@@ -699,10 +651,12 @@ func (self *SerialUdbExtraF4) Unpack(p *Packet) error {
 
 // Backwards compatible version of SERIAL_UDB_EXTRA F5: format
 type SerialUdbExtraF5 struct {
-	SueYawkpAileron float32 // Serial UDB YAWKP_AILERON Gain for Proporional control of navigation
-	SueYawkdAileron float32 // Serial UDB YAWKD_AILERON Gain for Rate control of navigation
-	SueRollkp       float32 // Serial UDB Extra ROLLKP Gain for Proportional control of roll stabilization
-	SueRollkd       float32 // Serial UDB Extra ROLLKD Gain for Rate control of roll stabilization
+	SueYawkpAileron            float32 // Serial UDB YAWKP_AILERON Gain for Proporional control of navigation
+	SueYawkdAileron            float32 // Serial UDB YAWKD_AILERON Gain for Rate control of navigation
+	SueRollkp                  float32 // Serial UDB Extra ROLLKP Gain for Proportional control of roll stabilization
+	SueRollkd                  float32 // Serial UDB Extra ROLLKD Gain for Rate control of roll stabilization
+	SueYawStabilizationAileron float32 // YAW_STABILIZATION_AILERON Proportional control
+	SueAileronBoost            float32 // Gain For Boosting Manual Aileron control When Plane Stabilized
 }
 
 func (self *SerialUdbExtraF5) MsgID() MessageID {
@@ -714,11 +668,13 @@ func (self *SerialUdbExtraF5) MsgName() string {
 }
 
 func (self *SerialUdbExtraF5) Pack(p *Packet) error {
-	payload := make([]byte, 16)
+	payload := make([]byte, 24)
 	binary.LittleEndian.PutUint32(payload[0:], math.Float32bits(self.SueYawkpAileron))
 	binary.LittleEndian.PutUint32(payload[4:], math.Float32bits(self.SueYawkdAileron))
 	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.SueRollkp))
 	binary.LittleEndian.PutUint32(payload[12:], math.Float32bits(self.SueRollkd))
+	binary.LittleEndian.PutUint32(payload[16:], math.Float32bits(self.SueYawStabilizationAileron))
+	binary.LittleEndian.PutUint32(payload[20:], math.Float32bits(self.SueAileronBoost))
 
 	p.MsgID = self.MsgID()
 	p.Payload = payload
@@ -726,13 +682,15 @@ func (self *SerialUdbExtraF5) Pack(p *Packet) error {
 }
 
 func (self *SerialUdbExtraF5) Unpack(p *Packet) error {
-	if len(p.Payload) < 16 {
+	if len(p.Payload) < 24 {
 		return fmt.Errorf("payload too small")
 	}
 	self.SueYawkpAileron = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[0:]))
 	self.SueYawkdAileron = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[4:]))
 	self.SueRollkp = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8:]))
 	self.SueRollkd = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[12:]))
+	self.SueYawStabilizationAileron = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[16:]))
+	self.SueAileronBoost = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[20:]))
 	return nil
 }
 
@@ -913,7 +871,7 @@ func (self *SerialUdbExtraF13) Unpack(p *Packet) error {
 // Backwards compatible version of SERIAL_UDB_EXTRA F14: format
 type SerialUdbExtraF14 struct {
 	SueTrapSource     uint32 // Serial UDB Extra Type Program Address of Last Trap
-	SueRcon           int16  // Serial UDB Extra Reboot Register of DSPIC
+	SueRcon           int16  // Serial UDB Extra Reboot Regitster of DSPIC
 	SueTrapFlags      int16  // Serial UDB Extra  Last dspic Trap Flags
 	SueOscFailCount   int16  // Serial UDB Extra Number of Ocillator Failures
 	SueWindEstimation uint8  // Serial UDB Extra Wind Estimation Enabled
@@ -970,7 +928,7 @@ func (self *SerialUdbExtraF14) Unpack(p *Packet) error {
 	return nil
 }
 
-// Backwards compatible version of SERIAL_UDB_EXTRA F15 format
+// Backwards compatible version of SERIAL_UDB_EXTRA F15 and F16: format
 type SerialUdbExtraF15 struct {
 	SueIdVehicleModelName    [40]uint8 // Serial UDB Extra Model Name Of Vehicle
 	SueIdVehicleRegistration [20]uint8 // Serial UDB Extra Registraton Number of Vehicle
@@ -1003,7 +961,7 @@ func (self *SerialUdbExtraF15) Unpack(p *Packet) error {
 	return nil
 }
 
-// Backwards compatible version of SERIAL_UDB_EXTRA F16 format
+//
 type SerialUdbExtraF16 struct {
 	SueIdLeadPilot    [40]uint8 // Serial UDB Extra Name of Expected Lead Pilot
 	SueIdDiyDronesUrl [70]uint8 // Serial UDB Extra URL of Lead Pilot or Team
@@ -1132,291 +1090,6 @@ func (self *Airspeeds) Unpack(p *Packet) error {
 	return nil
 }
 
-// Backwards compatible version of SERIAL_UDB_EXTRA F17 format
-type SerialUdbExtraF17 struct {
-	SueFeedForward float32 // SUE Feed Forward Gain
-	SueTurnRateNav float32 // SUE Max Turn Rate when Navigating
-	SueTurnRateFbw float32 // SUE Max Turn Rate in Fly By Wire Mode
-}
-
-func (self *SerialUdbExtraF17) MsgID() MessageID {
-	return MSG_ID_SERIAL_UDB_EXTRA_F17
-}
-
-func (self *SerialUdbExtraF17) MsgName() string {
-	return "SerialUdbExtraF17"
-}
-
-func (self *SerialUdbExtraF17) Pack(p *Packet) error {
-	payload := make([]byte, 12)
-	binary.LittleEndian.PutUint32(payload[0:], math.Float32bits(self.SueFeedForward))
-	binary.LittleEndian.PutUint32(payload[4:], math.Float32bits(self.SueTurnRateNav))
-	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.SueTurnRateFbw))
-
-	p.MsgID = self.MsgID()
-	p.Payload = payload
-	return nil
-}
-
-func (self *SerialUdbExtraF17) Unpack(p *Packet) error {
-	if len(p.Payload) < 12 {
-		return fmt.Errorf("payload too small")
-	}
-	self.SueFeedForward = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[0:]))
-	self.SueTurnRateNav = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[4:]))
-	self.SueTurnRateFbw = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8:]))
-	return nil
-}
-
-// Backwards compatible version of SERIAL_UDB_EXTRA F18 format
-type SerialUdbExtraF18 struct {
-	AngleOfAttackNormal   float32 // SUE Angle of Attack Normal
-	AngleOfAttackInverted float32 // SUE Angle of Attack Inverted
-	ElevatorTrimNormal    float32 // SUE Elevator Trim Normal
-	ElevatorTrimInverted  float32 // SUE Elevator Trim Inverted
-	ReferenceSpeed        float32 // SUE reference_speed
-}
-
-func (self *SerialUdbExtraF18) MsgID() MessageID {
-	return MSG_ID_SERIAL_UDB_EXTRA_F18
-}
-
-func (self *SerialUdbExtraF18) MsgName() string {
-	return "SerialUdbExtraF18"
-}
-
-func (self *SerialUdbExtraF18) Pack(p *Packet) error {
-	payload := make([]byte, 20)
-	binary.LittleEndian.PutUint32(payload[0:], math.Float32bits(self.AngleOfAttackNormal))
-	binary.LittleEndian.PutUint32(payload[4:], math.Float32bits(self.AngleOfAttackInverted))
-	binary.LittleEndian.PutUint32(payload[8:], math.Float32bits(self.ElevatorTrimNormal))
-	binary.LittleEndian.PutUint32(payload[12:], math.Float32bits(self.ElevatorTrimInverted))
-	binary.LittleEndian.PutUint32(payload[16:], math.Float32bits(self.ReferenceSpeed))
-
-	p.MsgID = self.MsgID()
-	p.Payload = payload
-	return nil
-}
-
-func (self *SerialUdbExtraF18) Unpack(p *Packet) error {
-	if len(p.Payload) < 20 {
-		return fmt.Errorf("payload too small")
-	}
-	self.AngleOfAttackNormal = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[0:]))
-	self.AngleOfAttackInverted = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[4:]))
-	self.ElevatorTrimNormal = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[8:]))
-	self.ElevatorTrimInverted = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[12:]))
-	self.ReferenceSpeed = math.Float32frombits(binary.LittleEndian.Uint32(p.Payload[16:]))
-	return nil
-}
-
-// Backwards compatible version of SERIAL_UDB_EXTRA F19 format
-type SerialUdbExtraF19 struct {
-	SueAileronOutputChannel  uint8 // SUE aileron output channel
-	SueAileronReversed       uint8 // SUE aileron reversed
-	SueElevatorOutputChannel uint8 // SUE elevator output channel
-	SueElevatorReversed      uint8 // SUE elevator reversed
-	SueThrottleOutputChannel uint8 // SUE throttle output channel
-	SueThrottleReversed      uint8 // SUE throttle reversed
-	SueRudderOutputChannel   uint8 // SUE rudder output channel
-	SueRudderReversed        uint8 // SUE rudder reversed
-}
-
-func (self *SerialUdbExtraF19) MsgID() MessageID {
-	return MSG_ID_SERIAL_UDB_EXTRA_F19
-}
-
-func (self *SerialUdbExtraF19) MsgName() string {
-	return "SerialUdbExtraF19"
-}
-
-func (self *SerialUdbExtraF19) Pack(p *Packet) error {
-	payload := make([]byte, 8)
-	payload[0] = byte(self.SueAileronOutputChannel)
-	payload[1] = byte(self.SueAileronReversed)
-	payload[2] = byte(self.SueElevatorOutputChannel)
-	payload[3] = byte(self.SueElevatorReversed)
-	payload[4] = byte(self.SueThrottleOutputChannel)
-	payload[5] = byte(self.SueThrottleReversed)
-	payload[6] = byte(self.SueRudderOutputChannel)
-	payload[7] = byte(self.SueRudderReversed)
-
-	p.MsgID = self.MsgID()
-	p.Payload = payload
-	return nil
-}
-
-func (self *SerialUdbExtraF19) Unpack(p *Packet) error {
-	if len(p.Payload) < 8 {
-		return fmt.Errorf("payload too small")
-	}
-	self.SueAileronOutputChannel = uint8(p.Payload[0])
-	self.SueAileronReversed = uint8(p.Payload[1])
-	self.SueElevatorOutputChannel = uint8(p.Payload[2])
-	self.SueElevatorReversed = uint8(p.Payload[3])
-	self.SueThrottleOutputChannel = uint8(p.Payload[4])
-	self.SueThrottleReversed = uint8(p.Payload[5])
-	self.SueRudderOutputChannel = uint8(p.Payload[6])
-	self.SueRudderReversed = uint8(p.Payload[7])
-	return nil
-}
-
-// Backwards compatible version of SERIAL_UDB_EXTRA F20 format
-type SerialUdbExtraF20 struct {
-	SueTrimValueInput1  int16 // SUE UDB PWM Trim Value on Input 1
-	SueTrimValueInput2  int16 // SUE UDB PWM Trim Value on Input 2
-	SueTrimValueInput3  int16 // SUE UDB PWM Trim Value on Input 3
-	SueTrimValueInput4  int16 // SUE UDB PWM Trim Value on Input 4
-	SueTrimValueInput5  int16 // SUE UDB PWM Trim Value on Input 5
-	SueTrimValueInput6  int16 // SUE UDB PWM Trim Value on Input 6
-	SueTrimValueInput7  int16 // SUE UDB PWM Trim Value on Input 7
-	SueTrimValueInput8  int16 // SUE UDB PWM Trim Value on Input 8
-	SueTrimValueInput9  int16 // SUE UDB PWM Trim Value on Input 9
-	SueTrimValueInput10 int16 // SUE UDB PWM Trim Value on Input 10
-	SueTrimValueInput11 int16 // SUE UDB PWM Trim Value on Input 11
-	SueTrimValueInput12 int16 // SUE UDB PWM Trim Value on Input 12
-	SueNumberOfInputs   uint8 // SUE Number of Input Channels
-}
-
-func (self *SerialUdbExtraF20) MsgID() MessageID {
-	return MSG_ID_SERIAL_UDB_EXTRA_F20
-}
-
-func (self *SerialUdbExtraF20) MsgName() string {
-	return "SerialUdbExtraF20"
-}
-
-func (self *SerialUdbExtraF20) Pack(p *Packet) error {
-	payload := make([]byte, 25)
-	binary.LittleEndian.PutUint16(payload[0:], uint16(self.SueTrimValueInput1))
-	binary.LittleEndian.PutUint16(payload[2:], uint16(self.SueTrimValueInput2))
-	binary.LittleEndian.PutUint16(payload[4:], uint16(self.SueTrimValueInput3))
-	binary.LittleEndian.PutUint16(payload[6:], uint16(self.SueTrimValueInput4))
-	binary.LittleEndian.PutUint16(payload[8:], uint16(self.SueTrimValueInput5))
-	binary.LittleEndian.PutUint16(payload[10:], uint16(self.SueTrimValueInput6))
-	binary.LittleEndian.PutUint16(payload[12:], uint16(self.SueTrimValueInput7))
-	binary.LittleEndian.PutUint16(payload[14:], uint16(self.SueTrimValueInput8))
-	binary.LittleEndian.PutUint16(payload[16:], uint16(self.SueTrimValueInput9))
-	binary.LittleEndian.PutUint16(payload[18:], uint16(self.SueTrimValueInput10))
-	binary.LittleEndian.PutUint16(payload[20:], uint16(self.SueTrimValueInput11))
-	binary.LittleEndian.PutUint16(payload[22:], uint16(self.SueTrimValueInput12))
-	payload[24] = byte(self.SueNumberOfInputs)
-
-	p.MsgID = self.MsgID()
-	p.Payload = payload
-	return nil
-}
-
-func (self *SerialUdbExtraF20) Unpack(p *Packet) error {
-	if len(p.Payload) < 25 {
-		return fmt.Errorf("payload too small")
-	}
-	self.SueTrimValueInput1 = int16(binary.LittleEndian.Uint16(p.Payload[0:]))
-	self.SueTrimValueInput2 = int16(binary.LittleEndian.Uint16(p.Payload[2:]))
-	self.SueTrimValueInput3 = int16(binary.LittleEndian.Uint16(p.Payload[4:]))
-	self.SueTrimValueInput4 = int16(binary.LittleEndian.Uint16(p.Payload[6:]))
-	self.SueTrimValueInput5 = int16(binary.LittleEndian.Uint16(p.Payload[8:]))
-	self.SueTrimValueInput6 = int16(binary.LittleEndian.Uint16(p.Payload[10:]))
-	self.SueTrimValueInput7 = int16(binary.LittleEndian.Uint16(p.Payload[12:]))
-	self.SueTrimValueInput8 = int16(binary.LittleEndian.Uint16(p.Payload[14:]))
-	self.SueTrimValueInput9 = int16(binary.LittleEndian.Uint16(p.Payload[16:]))
-	self.SueTrimValueInput10 = int16(binary.LittleEndian.Uint16(p.Payload[18:]))
-	self.SueTrimValueInput11 = int16(binary.LittleEndian.Uint16(p.Payload[20:]))
-	self.SueTrimValueInput12 = int16(binary.LittleEndian.Uint16(p.Payload[22:]))
-	self.SueNumberOfInputs = uint8(p.Payload[24])
-	return nil
-}
-
-// Backwards compatible version of SERIAL_UDB_EXTRA F21 format
-type SerialUdbExtraF21 struct {
-	SueAccelXOffset int16 // SUE X accelerometer offset
-	SueAccelYOffset int16 // SUE Y accelerometer offset
-	SueAccelZOffset int16 // SUE Z accelerometer offset
-	SueGyroXOffset  int16 // SUE X gyro offset
-	SueGyroYOffset  int16 // SUE Y gyro offset
-	SueGyroZOffset  int16 // SUE Z gyro offset
-}
-
-func (self *SerialUdbExtraF21) MsgID() MessageID {
-	return MSG_ID_SERIAL_UDB_EXTRA_F21
-}
-
-func (self *SerialUdbExtraF21) MsgName() string {
-	return "SerialUdbExtraF21"
-}
-
-func (self *SerialUdbExtraF21) Pack(p *Packet) error {
-	payload := make([]byte, 12)
-	binary.LittleEndian.PutUint16(payload[0:], uint16(self.SueAccelXOffset))
-	binary.LittleEndian.PutUint16(payload[2:], uint16(self.SueAccelYOffset))
-	binary.LittleEndian.PutUint16(payload[4:], uint16(self.SueAccelZOffset))
-	binary.LittleEndian.PutUint16(payload[6:], uint16(self.SueGyroXOffset))
-	binary.LittleEndian.PutUint16(payload[8:], uint16(self.SueGyroYOffset))
-	binary.LittleEndian.PutUint16(payload[10:], uint16(self.SueGyroZOffset))
-
-	p.MsgID = self.MsgID()
-	p.Payload = payload
-	return nil
-}
-
-func (self *SerialUdbExtraF21) Unpack(p *Packet) error {
-	if len(p.Payload) < 12 {
-		return fmt.Errorf("payload too small")
-	}
-	self.SueAccelXOffset = int16(binary.LittleEndian.Uint16(p.Payload[0:]))
-	self.SueAccelYOffset = int16(binary.LittleEndian.Uint16(p.Payload[2:]))
-	self.SueAccelZOffset = int16(binary.LittleEndian.Uint16(p.Payload[4:]))
-	self.SueGyroXOffset = int16(binary.LittleEndian.Uint16(p.Payload[6:]))
-	self.SueGyroYOffset = int16(binary.LittleEndian.Uint16(p.Payload[8:]))
-	self.SueGyroZOffset = int16(binary.LittleEndian.Uint16(p.Payload[10:]))
-	return nil
-}
-
-// Backwards compatible version of SERIAL_UDB_EXTRA F22 format
-type SerialUdbExtraF22 struct {
-	SueAccelXAtCalibration int16 // SUE X accelerometer at calibration time
-	SueAccelYAtCalibration int16 // SUE Y accelerometer at calibration time
-	SueAccelZAtCalibration int16 // SUE Z accelerometer at calibration time
-	SueGyroXAtCalibration  int16 // SUE X gyro at calibration time
-	SueGyroYAtCalibration  int16 // SUE Y gyro at calibration time
-	SueGyroZAtCalibration  int16 // SUE Z gyro at calibration time
-}
-
-func (self *SerialUdbExtraF22) MsgID() MessageID {
-	return MSG_ID_SERIAL_UDB_EXTRA_F22
-}
-
-func (self *SerialUdbExtraF22) MsgName() string {
-	return "SerialUdbExtraF22"
-}
-
-func (self *SerialUdbExtraF22) Pack(p *Packet) error {
-	payload := make([]byte, 12)
-	binary.LittleEndian.PutUint16(payload[0:], uint16(self.SueAccelXAtCalibration))
-	binary.LittleEndian.PutUint16(payload[2:], uint16(self.SueAccelYAtCalibration))
-	binary.LittleEndian.PutUint16(payload[4:], uint16(self.SueAccelZAtCalibration))
-	binary.LittleEndian.PutUint16(payload[6:], uint16(self.SueGyroXAtCalibration))
-	binary.LittleEndian.PutUint16(payload[8:], uint16(self.SueGyroYAtCalibration))
-	binary.LittleEndian.PutUint16(payload[10:], uint16(self.SueGyroZAtCalibration))
-
-	p.MsgID = self.MsgID()
-	p.Payload = payload
-	return nil
-}
-
-func (self *SerialUdbExtraF22) Unpack(p *Packet) error {
-	if len(p.Payload) < 12 {
-		return fmt.Errorf("payload too small")
-	}
-	self.SueAccelXAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[0:]))
-	self.SueAccelYAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[2:]))
-	self.SueAccelZAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[4:]))
-	self.SueGyroXAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[6:]))
-	self.SueGyroYAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[8:]))
-	self.SueGyroZAtCalibration = int16(binary.LittleEndian.Uint16(p.Payload[10:]))
-	return nil
-}
-
 // Message IDs
 const (
 	MSG_ID_FLEXIFUNCTION_SET                 MessageID = 150
@@ -1440,12 +1113,6 @@ const (
 	MSG_ID_SERIAL_UDB_EXTRA_F16              MessageID = 180
 	MSG_ID_ALTITUDES                         MessageID = 181
 	MSG_ID_AIRSPEEDS                         MessageID = 182
-	MSG_ID_SERIAL_UDB_EXTRA_F17              MessageID = 183
-	MSG_ID_SERIAL_UDB_EXTRA_F18              MessageID = 184
-	MSG_ID_SERIAL_UDB_EXTRA_F19              MessageID = 185
-	MSG_ID_SERIAL_UDB_EXTRA_F20              MessageID = 186
-	MSG_ID_SERIAL_UDB_EXTRA_F21              MessageID = 187
-	MSG_ID_SERIAL_UDB_EXTRA_F22              MessageID = 188
 )
 
 // DialectMatrixpilot is the dialect represented by matrixpilot.xml
@@ -1460,10 +1127,10 @@ var DialectMatrixpilot *Dialect = &Dialect{
 		MSG_ID_FLEXIFUNCTION_DIRECTORY_ACK:       218,
 		MSG_ID_FLEXIFUNCTION_COMMAND:             133,
 		MSG_ID_FLEXIFUNCTION_COMMAND_ACK:         208,
-		MSG_ID_SERIAL_UDB_EXTRA_F2_A:             103,
-		MSG_ID_SERIAL_UDB_EXTRA_F2_B:             245,
+		MSG_ID_SERIAL_UDB_EXTRA_F2_A:             150,
+		MSG_ID_SERIAL_UDB_EXTRA_F2_B:             169,
 		MSG_ID_SERIAL_UDB_EXTRA_F4:               191,
-		MSG_ID_SERIAL_UDB_EXTRA_F5:               54,
+		MSG_ID_SERIAL_UDB_EXTRA_F5:               121,
 		MSG_ID_SERIAL_UDB_EXTRA_F6:               54,
 		MSG_ID_SERIAL_UDB_EXTRA_F7:               171,
 		MSG_ID_SERIAL_UDB_EXTRA_F8:               142,
@@ -1473,12 +1140,6 @@ var DialectMatrixpilot *Dialect = &Dialect{
 		MSG_ID_SERIAL_UDB_EXTRA_F16:              222,
 		MSG_ID_ALTITUDES:                         55,
 		MSG_ID_AIRSPEEDS:                         154,
-		MSG_ID_SERIAL_UDB_EXTRA_F17:              175,
-		MSG_ID_SERIAL_UDB_EXTRA_F18:              41,
-		MSG_ID_SERIAL_UDB_EXTRA_F19:              87,
-		MSG_ID_SERIAL_UDB_EXTRA_F20:              144,
-		MSG_ID_SERIAL_UDB_EXTRA_F21:              134,
-		MSG_ID_SERIAL_UDB_EXTRA_F22:              91,
 	},
 	messageConstructorByMsgId: map[MessageID]func(*Packet) Message{
 		MSG_ID_FLEXIFUNCTION_SET: func(pkt *Packet) Message {
@@ -1583,36 +1244,6 @@ var DialectMatrixpilot *Dialect = &Dialect{
 		},
 		MSG_ID_AIRSPEEDS: func(pkt *Packet) Message {
 			msg := new(Airspeeds)
-			msg.Unpack(pkt)
-			return msg
-		},
-		MSG_ID_SERIAL_UDB_EXTRA_F17: func(pkt *Packet) Message {
-			msg := new(SerialUdbExtraF17)
-			msg.Unpack(pkt)
-			return msg
-		},
-		MSG_ID_SERIAL_UDB_EXTRA_F18: func(pkt *Packet) Message {
-			msg := new(SerialUdbExtraF18)
-			msg.Unpack(pkt)
-			return msg
-		},
-		MSG_ID_SERIAL_UDB_EXTRA_F19: func(pkt *Packet) Message {
-			msg := new(SerialUdbExtraF19)
-			msg.Unpack(pkt)
-			return msg
-		},
-		MSG_ID_SERIAL_UDB_EXTRA_F20: func(pkt *Packet) Message {
-			msg := new(SerialUdbExtraF20)
-			msg.Unpack(pkt)
-			return msg
-		},
-		MSG_ID_SERIAL_UDB_EXTRA_F21: func(pkt *Packet) Message {
-			msg := new(SerialUdbExtraF21)
-			msg.Unpack(pkt)
-			return msg
-		},
-		MSG_ID_SERIAL_UDB_EXTRA_F22: func(pkt *Packet) Message {
-			msg := new(SerialUdbExtraF22)
 			msg.Unpack(pkt)
 			return msg
 		},


### PR DESCRIPTION
Fields, that follow the "<extensions/>" element in mavlink protocol definition, must be ignored _at least_ for the purposes of calculating "extra CRC" (see https://github.com/ArduPilot/pymavlink/blob/0e949ae41c0db266c8a903a5bcc8d6d7e1bb5c20/generator/mavparse.py#L135). We also exclude them from generated go code, since we don't support mavlink v2 yet.